### PR TITLE
Properly unexclude all files under dev-lib in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,11 +270,12 @@ src.orig
 log.txt
 *.lnk
 *.lib
-!dev-lib/[^.]*
+*.dll
+!dev-lib/**
+/dev-lib/.*
 !doc/[^.]*
 .DS_Store
 *.exe
-*.dll
 *.tlog
 *.exp
 


### PR DESCRIPTION
Previously, the `.gitignore` was ignoring files under subdirectories of `dev-lib`, making critical files under `lib` not be included.