### PR TITLE
Remove incorrect and unused playSpaceMusic declaration in planets.h

### DIFF
--- a/src/uqm/planets/planets.h
+++ b/src/uqm/planets/planets.h
@@ -349,7 +349,6 @@ extern void GetPlanetOrMoonName (UNICODE *buf, COUNT bufsize);
 
 extern void PlanetOrbitMenu (void);
 extern void SaveSolarSysLocation (void);
-extern void playSpaceMusic(BOOLEAN ComingFromLoad);
 
 #if defined(__cplusplus)
 }

--- a/src/uqm/planets/solarsys.c
+++ b/src/uqm/planets/solarsys.c
@@ -1981,7 +1981,7 @@ spaceMusicSwitch(BYTE SpeciesID) {
 	}
 }
 
-void
+static void
 playSpaceMusic() {
 
 	if (!SpaceMusic) {


### PR DESCRIPTION
In Serosis/UQM-MegaMod-Archived#21, I accidentally left a declaration of `playSpaceMusic` that still had the old `ComingFromLoad` argument in `planets.h`. I'm not sure why this wasn't causing an error in Visual Studio builds, but it breaks builds with gcc. Since `playSpaceMusic` isn't used outside of `solarsys.c` anymore, I've removed that declaration and made the function static.