### PR TITLE
Fix netplay on modern versions of Visual Studio

### DIFF
--- a/src/uqm/supermelee/netplay/netmelee.c
+++ b/src/uqm/supermelee/netplay/netmelee.c
@@ -16,6 +16,8 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#define PORT_WANT_ERRNO
+#include "port.h"
 #include "netmelee.h"
 #include "libs/async.h"
 #include "libs/callback.h"
@@ -196,7 +198,7 @@ flushPacketQueues(void) {
 			continue;
 
 		flushStatus = flushPacketQueue(conn);
-		if (flushStatus == -1 && errno != EAGAIN)
+		if (flushStatus == -1 && errno != EAGAIN && errno != EWOULDBLOCK)
 			closePlayerNetworkConnection(player);
 	}
 }

--- a/src/uqm/supermelee/netplay/netrcv.c
+++ b/src/uqm/supermelee/netplay/netrcv.c
@@ -146,19 +146,18 @@ dataReadyCallback(NetDescriptor *nd) {
 		}
 
 		if (numRead == -1) {
-			switch (errno) {
-				case EAGAIN:  // No more data for now.
-					return;
-				case EINTR:  // System call was interrupted. Retry.
-					continue;
-				default: {
-					int savedErrno = errno;
-					log_add(log_Error, "recv() failed: %s.\n",
-							strerror(errno));
-					NetConnection_doErrorCallback(conn, savedErrno);
-					NetDescriptor_close(nd);
-					return;
-				}
+			if (errno == EWOULDBLOCK || errno == EAGAIN)
+				return;  // No more data for now.
+			else if (errno == EINTR)
+				continue;  // System call was interrupted. Retry.
+			else
+			{
+				int savedErrno = errno;
+				log_add (log_Error, "recv() failed: %s.\n",
+					strerror (errno));
+				NetConnection_doErrorCallback (conn, savedErrno);
+				NetDescriptor_close (nd);
+				return;
 			}
 		}
 

--- a/src/uqm/supermelee/netplay/packetq.c
+++ b/src/uqm/supermelee/netplay/packetq.c
@@ -104,8 +104,8 @@ queuePacket(NetConnection *conn, Packet *packet) {
 
 // If an error occurs during sending, we leave the unsent packets in
 // the queue, and let the caller decide what to do with them.
-// This function may return -1 with errno EAGAIN if we're waiting for
-// the other party to act first.
+// This function may return -1 with errno EAGAIN or EWOULDBLOCK
+// if we're waiting for the other party to act first.
 static int
 flushPacketQueueLinks(NetConnection *conn, PacketQueueLink **first) {
 	PacketQueueLink *link;


### PR DESCRIPTION
When checking the `errno` from `Socket_recv`, `dataReadyCallback` only checked for `EAGAIN` and not `EWOULDBLOCK`, which is what is returned by Winsock when there is no data available (well, Winsock returns `WSAEWOULDBLOCK` and `winsockErrorToErrno` converts it to `EWOULDBLOCK`).

In Visual Studio 2008, this was not an issue, as `EWOULDBLOCK` is not defined by `errno.h` and so is left to `port.h` to define, which defines it as equal to `EAGAIN` if possible. In more modern versions of Visual Studio, however, `EWOULDBLOCK` *is* defined and is not equal to `EAGAIN`. Because `dataReadyCallback` doesn't recognize the error, it assumes that it's fatal and terminates the connection.  
(Note: I changed the `switch` to an `if/else if/else` series because otherwise there would be a duplicate `case` if `EAGAIN` were equal to `EWOULDBLOCK`)

I've also preemptively fixed another instance of checking for `EAGAIN` and not `EWOULDBLOCK` in `netmelee.c`. These are the only two potential instances of the issue (confirmed by a global search for `EAGAIN`).

Fixes #6.