### PR TITLE
Fix OpenAL on 64-bit builds

### DIFF
--- a/src/libs/sound/mixer/nosound/audiodrv_nosound.c
+++ b/src/libs/sound/mixer/nosound/audiodrv_nosound.c
@@ -93,6 +93,43 @@ static const audio_Driver noSound_Driver =
 	noSound_BufferData
 };
 
+/* Adapted from SDL
+ * This will generate "negative subscript or subscript is too large"
+ * error during compile, if the size of a type is wrong
+ */
+#define UQM_COMPILE_TIME_ASSERT(name, x) \
+	typedef int UQM_dummy_##name [(x) * 2 - 1]
+
+UQM_COMPILE_TIME_ASSERT (mixer_Object_fits_in_audio_Object,
+	sizeof (mixer_Object) <= sizeof (audio_Object));
+
+#undef UQM_COMPILE_TIME_ASSERT
+
+// Converts an array of n audio_Objects to an array of mixer_Objects, in place.
+static void
+noSound_ConvertObjectArrayToMixerObjects (uint32 n, audio_Object *arr)
+{
+	if (sizeof (audio_Object) == sizeof (mixer_Object))
+		return;
+	uint32 i;
+	for (i = 0; i < n; i++)
+	{
+		((mixer_Object *) arr)[i] = arr[i];
+	}
+
+}
+// Converts an array of n mixer_Objects to an array of audio_Objects, in place.
+static void
+noSound_ConvertObjectArrayFromMixerObjects (uint32 n, audio_Object *arr)
+{
+	if (sizeof (audio_Object) == sizeof (mixer_Object))
+		return;
+	uint32 i = n;
+	while (i--)
+	{
+		arr[i] = ((mixer_Object *) arr)[i];
+	}
+}
 
 /*
  * Initialization
@@ -257,12 +294,15 @@ void
 noSound_GenSources (uint32 n, audio_Object *psrcobj)
 {
 	mixer_GenSources (n, (mixer_Object *) psrcobj);
+	noSound_ConvertObjectArrayFromMixerObjects (n, psrcobj);
 }
 
 void
 noSound_DeleteSources (uint32 n, audio_Object *psrcobj)
 {
+	noSound_ConvertObjectArrayToMixerObjects (n, psrcobj);
 	mixer_DeleteSources (n, (mixer_Object *) psrcobj);
+	noSound_ConvertObjectArrayFromMixerObjects (n, psrcobj);
 }
 
 bool
@@ -298,8 +338,10 @@ void
 noSound_GetSourcei (audio_Object srcobj, audio_SourceProp pname,
 		audio_IntVal *value)
 {
+	mixer_IntVal temp = *value;
 	mixer_GetSourcei ((mixer_Object) srcobj, (mixer_SourceProp) pname,
-			(mixer_IntVal *) value);
+			&temp);
+	*value = temp;
 	if (pname == MIX_SOURCE_STATE)
 	{
 		switch (*value)
@@ -359,16 +401,20 @@ void
 noSound_SourceQueueBuffers (audio_Object srcobj, uint32 n,
 		audio_Object* pbufobj)
 {
+	noSound_ConvertObjectArrayToMixerObjects (n, pbufobj);
 	mixer_SourceQueueBuffers ((mixer_Object) srcobj, n,
 			(mixer_Object *) pbufobj);
+	noSound_ConvertObjectArrayFromMixerObjects (n, pbufobj);
 }
 
 void
 noSound_SourceUnqueueBuffers (audio_Object srcobj, uint32 n,
 		audio_Object* pbufobj)
 {
+	noSound_ConvertObjectArrayToMixerObjects (n, pbufobj);
 	mixer_SourceUnqueueBuffers ((mixer_Object) srcobj, n,
 			(mixer_Object *) pbufobj);
+	noSound_ConvertObjectArrayFromMixerObjects (n, pbufobj);
 }
 
 
@@ -380,12 +426,15 @@ void
 noSound_GenBuffers (uint32 n, audio_Object *pbufobj)
 {
 	mixer_GenBuffers (n, (mixer_Object *) pbufobj);
+	noSound_ConvertObjectArrayFromMixerObjects (n, pbufobj);
 }
 
 void
 noSound_DeleteBuffers (uint32 n, audio_Object *pbufobj)
 {
+	noSound_ConvertObjectArrayToMixerObjects (n, pbufobj);
 	mixer_DeleteBuffers (n, (mixer_Object *) pbufobj);
+	noSound_ConvertObjectArrayFromMixerObjects (n, pbufobj);
 }
 
 bool
@@ -398,8 +447,10 @@ void
 noSound_GetBufferi (audio_Object bufobj, audio_BufferProp pname,
 		audio_IntVal *value)
 {
+	mixer_IntVal temp = *value;
 	mixer_GetBufferi ((mixer_Object) bufobj, (mixer_BufferProp) pname,
-			(mixer_IntVal *) value);
+			&temp);
+	*value = temp;
 }
 
 void


### PR DESCRIPTION
The OpenAL audio driver was assuming that the size of `audio_IntVal` and `audio_Object` were the same as `ALint` and `ALuint`. This is wrong on 64-bit builds, as `audio_IntVal` and `audio_Object` are defined as `intptr_t` and `uintptr_t` while `ALint` and `ALuint` are defined as `int` and `unsigned int`. This caused a crash when playing any sound with OpenAL.

The MixSDL and nosound drivers were making the same assumption with `mixer_IntVal` and `mixer_Object`, but this wasn't currently an issue since they're also defined as `intptr_t`. I've added the same code to them to ensure they still work if `audio_IntVal` and `_Object` ever become larger than `mixer_IntVal` and `_Object`.

(This also affects base UQM; if I could, I'd submit the patch to their bug tracker, but it's down.)