### PR TITLE
Allow parallelization of build.sh builds with -j

### DIFF
--- a/build/unix/build.sh
+++ b/build/unix/build.sh
@@ -58,6 +58,22 @@ fi
 # Load the configuration functions
 . build/unix/build.config
 
+BUILD_THREADS=1
+for i in "$@"; do
+	shift
+	if [ "`printf "%s" "$i" | cut -c1-2`" = "-j" ]; then
+		num="`printf "%s" "$i" | cut -c3-`"
+		if [ -z "$num" ] || [ "$num" -gt 0 ] 2>/dev/null; then
+			BUILD_THREADS="$num"
+		else
+			usage 1>&2
+			exit 1
+		fi
+	else
+		set -- "$@" "$i"
+	fi
+done
+
 case "$1" in
 	cleanall)
 		build_cleanall
@@ -93,7 +109,7 @@ export "${BUILD_PROJECT}_OBJS"
 if [ $# -lt 2 ]; then
 	build_check_config
 	build_check_dependencies
-	build_compile
+	build_compile $BUILD_THREADS
 	exit $?
 fi
 
@@ -115,7 +131,7 @@ case "$2" in
 	install)
 		build_check_config
 		build_check_dependencies
-		build_check_compile
+		build_check_compile $BUILD_THREADS
 		build_install
 		;;
 	*)

--- a/build/unix/build_functions
+++ b/build/unix/build_functions
@@ -22,11 +22,11 @@ usage() {
 	echo "Main build script"
 	echo
 	echo "Syntax:"
-	echo "    ./build.sh <target>"
+	echo "    ./build.sh [-j[#JOBS]] <target>"
 	echo "    ./build.sh <target> config"
 	echo "    ./build.sh <target> depend"
 	echo "    ./build.sh <target> clean"
-	echo "    ./build.sh <target> install"
+	echo "    ./build.sh [-j[#JOBS]] <target> install"
 	echo "    ./build.sh cleanall"
 	echo "    ./build.sh distclean"
 	echo
@@ -103,6 +103,7 @@ build_depend() {
 
 # Compile the lot.
 # With the depend info set up, we can leave everything to make.
+# $1 - number of threads to use when building (empty for unlimited)
 build_compile() {
 	local CFLAGS CXXFLAGS LDFLAGS TARGET_FILE DEPEND_FILE OBJDIR
 
@@ -120,7 +121,7 @@ build_compile() {
 			BUILD_ROOT= \
 			TARGET_FILE=$TARGET_FILE DEPEND_FILE=$DEPEND_FILE \
 			SED=$SED \
-			$MAKE -f Makefile.build "$TARGET_FILE"
+			$MAKE -j$1 -f Makefile.build "$TARGET_FILE"
 
 	eval "${TARGET}_post_build"
 }
@@ -172,12 +173,13 @@ build_check_dependencies() {
 }
 
 # Description: check if the program is compiled, and otherwise compile
+# $1 - number of threads to use when building (empty for unlimited)
 build_check_compile() {
 	local NAME
 	eval NAME="\${${BUILD_PROJECT}_NAME}"
 	[ ! -e "$NAME" ] || return
 
-	build_compile || exit $?
+	build_compile $1 || exit $?
 }
 
 # Make a directory path, with mode and owner specified.


### PR DESCRIPTION
This PR allows the number of threads to use when compiling to be specified with `-j<#>`. Since `build.sh` already uses make, implementing this was as simple as passing the option through to it.

Compiling a full debug build (including OpenAL) on my computer (i7-4900MQ, quad core with hyperthreading) using `-j8` takes:
* 25-30 seconds on MinGW
* **6 seconds** on Linux (Kubuntu 19.04)