### PR TITLE
Make HD Sa-Matra battle more faithful to original

### DIFF
--- a/src/uqm/ships/lastbat/lastbat.c
+++ b/src/uqm/ships/lastbat/lastbat.c
@@ -787,14 +787,14 @@ samatra_preprocess (ELEMENT *ElementPtr)
 		
 		POINT offs_hd[] =
 		{
-			{-305, -234}, // Top left generator
-			{-414, -96 }, // The one below the top left generator
-			{-396,  140},
-			{-208,  262},
-			{215,   262},
-			{410,   140},
-			{441,  -87 },
-			{329,  -214}, // Top right generator
+			{-412, -140},
+			{-150, -290},
+			{ 150, -294},
+			{ 398, -180},
+			{ 428,  130},
+			{ 280,  250},
+			{-275,  254},
+			{-429,  133},
 		};
 		
 		POINT *offs;


### PR DESCRIPTION
This PR, along with Serosis/UQM-MegaMod-Content#5, changes the size and positions of the Sa-Matra's HD generators and the look of its fireballs to be more faithful to the original. Here's a comparison:

![samcompare](https://user-images.githubusercontent.com/7238529/66368140-f8f2ee00-e94b-11e9-87a5-bccc6a88e6a1.png)

This PR changes the positions of the generators in `lastbat.c` and must be merged together with Serosis/UQM-MegaMod-Content#5.