### PR TITLE
Restart melee menu music after viewing ship info

### DIFF
--- a/src/uqm/supermelee/buildpick.c
+++ b/src/uqm/supermelee/buildpick.c
@@ -147,7 +147,7 @@ DoPickShip (MELEE_STATE *pMS)
 			&& (pMS->currentShip != MELEE_NONE))
 	{
 		// Show ship spin video.
-		DoShipSpin (pMS->currentShip, (MUSIC_REF) 0);
+		DoShipSpin (pMS->currentShip, pMS->hMusic);
 		return TRUE;
 	}
 


### PR DESCRIPTION
Previously, the melee menu music would stop and never restart when a ship spin was opened or a ship slide was closed.