### PR TITLE
Improve performance of melee smooth zoom on Visual Studio builds

### DIFF
--- a/src/libs/graphics/sdl/canvas.c
+++ b/src/libs/graphics/sdl/canvas.c
@@ -1210,7 +1210,15 @@ blend_ratio_2 (Uint8 c1, Uint8 c2, int ratio)
 	return (((c1 - c2) * ratio) >> 8) + c2;
 }
 
-static inline Uint32
+static
+#ifdef _MSC_VER
+// The MSVC compiler doesn't inline this function without __forceinline,
+// which causes significant performance issues with trilinear scaling.
+__forceinline
+#else
+inline
+#endif
+Uint32
 scale_read_pixel (void* ppix, SDL_PixelFormat *fmt, SDL_Color *pal,
 				Uint32 mask, Uint32 key)
 {


### PR DESCRIPTION
The MSVC compiler was not inlining `scale_read_pixel` (despite it being marked as `inline`) even on release builds, which negatively affected the performance of the TFB_Canvas scalers. On my laptop, this was causing noticeable lag in the HD Sa-Matra battle when CPU throttling was enabled. This PR fixes the issue by using `__forceinline` instead of `inline` on Visual Studio builds.

(gcc does not have this issue.)