### PR TITLE
Fix Visual Studio 2008 builds

### DIFF
--- a/src/libs/sound/mixer/nosound/audiodrv_nosound.c
+++ b/src/libs/sound/mixer/nosound/audiodrv_nosound.c
@@ -109,9 +109,9 @@ UQM_COMPILE_TIME_ASSERT (mixer_Object_fits_in_audio_Object,
 static void
 noSound_ConvertObjectArrayToMixerObjects (uint32 n, audio_Object *arr)
 {
+	uint32 i;
 	if (sizeof (audio_Object) == sizeof (mixer_Object))
 		return;
-	uint32 i;
 	for (i = 0; i < n; i++)
 	{
 		((mixer_Object *) arr)[i] = arr[i];
@@ -122,9 +122,10 @@ noSound_ConvertObjectArrayToMixerObjects (uint32 n, audio_Object *arr)
 static void
 noSound_ConvertObjectArrayFromMixerObjects (uint32 n, audio_Object *arr)
 {
+	uint32 i;
 	if (sizeof (audio_Object) == sizeof (mixer_Object))
 		return;
-	uint32 i = n;
+	i = n;
 	while (i--)
 	{
 		arr[i] = ((mixer_Object *) arr)[i];

--- a/src/libs/sound/mixer/sdl/audiodrv_sdl.c
+++ b/src/libs/sound/mixer/sdl/audiodrv_sdl.c
@@ -105,9 +105,9 @@ UQM_COMPILE_TIME_ASSERT (mixer_Object_fits_in_audio_Object,
 static void
 mixSDL_ConvertObjectArrayToMixerObjects (uint32 n, audio_Object *arr)
 {
+	uint32 i;
 	if (sizeof (audio_Object) == sizeof (mixer_Object))
 		return;
-	uint32 i;
 	for (i = 0; i < n; i++)
 	{
 		((mixer_Object *) arr)[i] = arr[i];
@@ -118,9 +118,10 @@ mixSDL_ConvertObjectArrayToMixerObjects (uint32 n, audio_Object *arr)
 static void
 mixSDL_ConvertObjectArrayFromMixerObjects (uint32 n, audio_Object *arr)
 {
+	uint32 i;
 	if (sizeof (audio_Object) == sizeof (mixer_Object))
 		return;
-	uint32 i = n;
+	i = n;
 	while (i--)
 	{
 		arr[i] = ((mixer_Object *) arr)[i];

--- a/src/libs/sound/openal/audiodrv_openal.c
+++ b/src/libs/sound/openal/audiodrv_openal.c
@@ -115,9 +115,9 @@ UQM_COMPILE_TIME_ASSERT (ALuint_fits_in_audio_Object,
 static void
 openAL_ConvertObjectArrayToALuints (uint32 n, audio_Object *arr)
 {
+	uint32 i;
 	if (sizeof (audio_Object) == sizeof (ALuint))
 		return;
-	uint32 i;
 	for (i = 0; i < n; i++)
 	{
 		((ALuint *) arr)[i] = arr[i];
@@ -128,9 +128,10 @@ openAL_ConvertObjectArrayToALuints (uint32 n, audio_Object *arr)
 static void
 openAL_ConvertObjectArrayFromALuints (uint32 n, audio_Object *arr)
 {
+	uint32 i;
 	if (sizeof (audio_Object) == sizeof (ALuint))
 		return;
-	uint32 i = n;
+	i = n;
 	while (i--)
 	{
 		arr[i] = ((ALuint *) arr)[i];


### PR DESCRIPTION
This removes some C99-specific code (variable declarations after the start of a block) that I introduced in #9 without realizing that VS2008 doesn't support C99.