### PR TITLE
Scale sliders in HD

### DIFF
--- a/src/libs/graphics/widgets.c
+++ b/src/libs/graphics/widgets.c
@@ -450,16 +450,16 @@ Widget_DrawSlider(WIDGET *_self, int x, int y)
 	t.baseline.x -= t.baseline.x;
 
 	r.corner.x = t.baseline.x + 3 * tick;
-	r.corner.y = t.baseline.y - 4;
-	r.extent.height = 2;
+	r.corner.y = t.baseline.y - RES_SCALE (4);
+	r.extent.height = RES_SCALE (2);
 	r.extent.width = 3 * tick;
 	DrawFilledRectangle (&r);
 
-	r.extent.width = 3;
-	r.extent.height = 8;
-	r.corner.y = t.baseline.y - 7;
+	r.extent.width = RES_SCALE (3);
+	r.extent.height = RES_SCALE (8);
+	r.corner.y = t.baseline.y - RES_SCALE (7);
 	r.corner.x = t.baseline.x + 3 * tick + (3 * tick * (self->value - self->min) /
-		(self->max - self->min)) - 1;
+		(self->max - self->min)) - (RES_SCALE (3) >> 1);
 	DrawFilledRectangle (&r);
 
 	(*self->draw_value)(self, t.baseline.x + 7 * tick, t.baseline.y);


### PR DESCRIPTION
The setting sliders were not scaled in HD, making them look tiny and misaligned. Here's a comparison:

![image](https://user-images.githubusercontent.com/7238529/67545627-a8e78b80-f6ae-11e9-9535-79cf798cf8cb.png)