### PR TITLE
Add basic 2D positional audio support to MixSDL and fix attenuation in HD

### DIFF
--- a/src/libs/sound/mixer/mixer.h
+++ b/src/libs/sound/mixer/mixer.h
@@ -192,6 +192,8 @@ struct _mixer_Source
 	mixer_SourceState state;
 	bool looping;
 	float gain;
+	float leftGain;
+	float rightGain;
 	uint32 cqueued;
 	uint32 cprocessed;
 	mixer_Buffer *firstqueued; /* first buf in the queue */

--- a/src/uqm/sounds.c
+++ b/src/uqm/sounds.c
@@ -124,6 +124,8 @@ CalcSoundPosition (ELEMENT *ElementPtr)
 
 		pos.x -= (SPACE_WIDTH >> 1);
 		pos.y -= (SPACE_HEIGHT >> 1);
+		pos.x = RES_DESCALE (pos.x);
+		pos.y = RES_DESCALE (pos.y);
 		pos.positional = TRUE;
 	}
 


### PR DESCRIPTION
This adds basic positional audio support to the MixSDL driver and fixes the scaling of audio source positions in HD.

(This just uses the cosine of the angle to the source for panning - OpenAL's positional audio is probably a lot more advanced.)

The former change (8a97913) is also applicable to base UQM.