### PR TITLE
Fixed FUEL menu option highlight on outfit menu

### DIFF
--- a/src/uqm/outfit.c
+++ b/src/uqm/outfit.c
@@ -840,6 +840,7 @@ ExitOutfit:
 			}
 			case OUTFIT_DOFUEL:
 				pMS->CurState = OUTFIT_FUEL;
+				DrawMenuStateStrings(PM_FUEL, pMS->CurState);
 				SetFlashRect (SFR_MENU_3DO, FALSE);
 				break;
 			case OUTFIT_MODULES:

--- a/src/uqm/sis.c
+++ b/src/uqm/sis.c
@@ -1283,7 +1283,10 @@ static void
 DeltaSISGauges_resunitDelta (SIZE resunit_delta)
 {
 	if (resunit_delta == 0)
+	{
+		DrawStatusMessage(NULL);
 		return;
+	}
 
 	if (resunit_delta != UNDEFINED_DELTA)
 	{


### PR DESCRIPTION
Fixed _FUEL(20)_ not being highlighted if you're finishing changing fuel value by pressing ENTER key.