### PR TITLE
fix compilation issues on MacOS 12.0.1 / clang 13.0.0

### DIFF
--- a/src/uqm/planets/generate/genvault.c
+++ b/src/uqm/planets/generate/genvault.c
@@ -25,6 +25,7 @@
 #include "../../state.h"
 #include "../../build.h"
 #include "libs/mathlib.h"
+#include "../../comm.h"
 
 
 static bool GenerateVault_generatePlanets (SOLARSYS_STATE *solarSys);

--- a/src/uqm/planets/generate/genwreck.c
+++ b/src/uqm/planets/generate/genwreck.c
@@ -25,6 +25,7 @@
 #include "../../state.h"
 #include "../../build.h"
 #include "libs/mathlib.h"
+#include "../../comm.h"
 
 static bool GenerateWreck_generatePlanets (SOLARSYS_STATE *solarSys);
 static bool GenerateWreck_generateOrbital (SOLARSYS_STATE *solarSys,

--- a/src/uqm/planets/orbits.c
+++ b/src/uqm/planets/orbits.c
@@ -23,6 +23,7 @@
 #include "libs/log.h"
 #include "../clock.h"
 #include <math.h>
+#include <stdlib.h>
 
 //#define DEBUG_ORBITS
 


### PR DESCRIPTION
This fixes some compilation issues on MacOS 12.0.1 / clang 13.0.0; the correct headers weren't included, causing "implicit declaration of function" warnings, which are treated as errors by default.