### PR TITLE
Comm fixes

### DIFF
--- a/src/libs/gfxlib.h
+++ b/src/libs/gfxlib.h
@@ -551,6 +551,7 @@ extern BOOLEAN ReadFramePixelIndexes (FRAME frame, BYTE *pixels,
 extern BOOLEAN WriteFramePixelIndexes (FRAME frame, const BYTE *pixels,
 		int width, int height);
 extern void SetFrameTransparentColor (FRAME, Color);
+extern BOOLEAN IsFrameIndexed (FRAME Frame);
 
 // If the frame is an active SCREEN_DRAWABLE, this call must be
 // preceeded by FlushGraphics() for draw commands to have taken effect

--- a/src/libs/graphics/pixmap.c
+++ b/src/libs/graphics/pixmap.c
@@ -88,7 +88,6 @@ SetAbsFrameIndex (FRAME FramePtr, COUNT FrameIndex)
 		FrameIndex = FrameIndex	% (DrawablePtr->MaxIndex + 1);
 		FramePtr = &DrawablePtr->Frame[FrameIndex];
 	}
-
 	return FramePtr;
 }
 
@@ -167,4 +166,10 @@ DecFrameIndex (FRAME FramePtr)
 		DrawablePtr = GetFrameParentDrawable (FramePtr);
 		return &DrawablePtr->Frame[DrawablePtr->MaxIndex];
 	}
+}
+
+BOOLEAN
+IsFrameIndexed (FRAME FramePtr)
+{
+	return TFB_DrawCanvas_IsPaletted (FramePtr->image->NormalImg);
 }

--- a/src/uqm/comm.c
+++ b/src/uqm/comm.c
@@ -1934,6 +1934,8 @@ HailAlien (void)
 	DestroyFont (PlayerFont);
 	DestroyFont (ComputerFont);
 
+	ReleaseTalkingAnim ();
+
 	// Some support code tests either of these to see if the
 	// game is currently in comm or encounter
 	CommData.ConversationPhrasesRes = 0;

--- a/src/uqm/comm/blackur/blackurc.c
+++ b/src/uqm/comm/blackur/blackurc.c
@@ -118,7 +118,7 @@ static LOCDATA blackurq_desc =
 		1, /* StartIndex */
 		2, /* NumFrames */
 		0, /* AnimFlags */
-		ONE_SECOND / 6, 0, /* FrameRate */
+		ONE_SECOND / 30, 0, /* FrameRate */
 		0, 0, /* RestartRate */
 		0, /* BlockMask */
 	},

--- a/src/uqm/comm/chmmr/chmmrc.c
+++ b/src/uqm/comm/chmmr/chmmrc.c
@@ -557,11 +557,9 @@ Intro (void)
 			if (!IS_HD)
 				CommData.AlienColorMap = SetAbsColorMapIndex (
 						CommData.AlienColorMap, 1
-						);
-
-			// JMS_GFX: Use separate graphics in hires instead of colormap transform.
-			if (IS_HD)
-			{
+						);			
+			else
+			{// JMS_GFX: Use separate graphics in hires instead of colormap transform.
 				CommData.AlienFrameRes = CHMMR_RED_PMAP_ANIM;
 				CommData.AlienFrame = CaptureDrawable (
 					LoadGraphic (CommData.AlienFrameRes));

--- a/src/uqm/comm/comandr/resinst.h
+++ b/src/uqm/comm/comandr/resinst.h
@@ -8,6 +8,7 @@
 #define COMMANDER_LOWPOW_MUSIC "comm.commander.lowpower.music"
 #define COMMANDER_MUSIC "comm.commander.music"
 #define COMMANDER_PMAP_ANIM "comm.commander.graphics"
+#define COMMANDER_INIT_PMAP_ANIM "comm.starbas.graphics"
 #define COMMANDER_PMAP_ANIM_RED "comm.commander.red.graphics"
 #define COMMANDER_SCRIPT "comm.commander.script"
 #define STARBASE_ALT_MUSIC "comm.starbase.music"

--- a/src/uqm/comm/mycon/myconc.c
+++ b/src/uqm/comm/mycon/myconc.c
@@ -43,24 +43,29 @@ static LOCDATA mycon_desc =
 	NULL_RESOURCE, /* AlienAltSong */
 	0, /* AlienSongFlags */
 	MYCON_CONVERSATION_PHRASES, /* PlayerPhrases */
-	5, /* NumAnimations */
+	4, /* NumAnimations */
 	{ /* AlienAmbientArray (ambient animations) */
 		{
 			12, /* StartIndex */
-			6, /* NumFrames */
+			10, /* NumFrames */
 			CIRCULAR_ANIM, /* AnimFlags */
 			ONE_SECOND * 3 / 40, 0, /* FrameRate */
-			ONE_SECOND * 3 / 40, 0, /* RestartRate */
+			ONE_SECOND * 3 / 80, 0, /* RestartRate */
 			0, /* BlockMask */
 		},
-		{
-			18, /* StartIndex */
-			4, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
-			ONE_SECOND * 3 / 40, 0, /* FrameRate */
-			ONE_SECOND * 3 / 40, 0, /* RestartRate */
-			0, /* BlockMask */
-		},
+	//	{// It was 2 differtent animations that blocks each other
+	//	 // but after the commit BlockMask algorithm was changed
+	//	 // https://sourceforge.net/p/sc2/uqm/ci/5be8df3e5f4a957fa1ee63851e7e064731aadb20/
+	//   // and these animations completely cancel each other.
+	//   // Removing BlockMask messes with the animations restart rate,
+	//   // so these animations are now merged together
+	//		18, /* StartIndex */
+	//		4, /* NumFrames */
+	//		CIRCULAR_ANIM, /* AnimFlags */
+	//		ONE_SECOND * 3 / 40, 0, /* FrameRate */
+	//		ONE_SECOND * 3 / 40, 0, /* RestartRate */
+	//		(1 << 0), /* BlockMask */
+	//	},
 		{
 			22, /* StartIndex */
 			6, /* NumFrames */

--- a/src/uqm/comm/orz/orzc.c
+++ b/src/uqm/comm/orz/orzc.c
@@ -157,7 +157,8 @@ static LOCDATA orz_desc =
 		{
 			129, /* StartIndex */
 			5, /* NumFrames */
-			CIRCULAR_ANIM | ONE_SHOT_ANIM | WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
+			CIRCULAR_ANIM | ONE_SHOT_ANIM | 
+			WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			0, 0, /* RestartRate */
 			0, /* BlockMask */
@@ -242,28 +243,21 @@ ExitConversation (RESPONSE_REF R)
 		// JMS_GFX: Use separate graphics in hires instead of colormap transform.
 		if (IS_HD)
 		{
-			int ii;
-			for (ii = 0; ii < CommData.NumAnimations - 1; ii++)
-				CommData.AlienAmbientArray[ii].AnimFlags |= ANIM_DISABLED;
-			
-			CommData.AlienAmbientArray[13].AnimFlags &= ~ANIM_DISABLED;
 			CommData.AlienFrameRes = ORZ_ANGRY_PMAP_ANIM;
 			CommData.AlienFrame = CaptureDrawable (LoadGraphic (CommData.AlienFrameRes));
+			RunOneTimeSequence (13, RESTART_ALL_AFTER);
+		}
+		else
+		{
+			XFormColorMap(GetColorMapAddress(
+				SetAbsColorMapIndex(CommData.AlienColorMap, 1)
+			), ONE_SECOND / 2);
 		}
 
 		if (PLAYER_SAID (R, about_andro_3))
 			NPCPhrase (BLEW_IT);
 		else
 			NPCPhrase (KNOW_TOO_MUCH);
-
-		// JMS_GFX: Use separate graphics in hires instead of colormap transform.
-		if (IS_HD)
-		{
-			int ii;
-			AlienTalkSegue (1);
-			for (ii = 0; ii < CommData.NumAnimations - 1; ii++)
-				CommData.AlienAmbientArray[ii].AnimFlags &= ~ANIM_DISABLED;
-		}
 
 		SET_GAME_STATE (ORZ_VISITS, 0);
 		SET_GAME_STATE (ORZ_MANNER, 2);
@@ -274,9 +268,7 @@ ExitConversation (RESPONSE_REF R)
 			RemoveEscortShips (ORZ_SHIP);
 		}
 
-		XFormColorMap (GetColorMapAddress (
-				SetAbsColorMapIndex (CommData.AlienColorMap, 1)
-				), ONE_SECOND / 2);
+		
 	}
 	else /* insults */
 	{
@@ -679,15 +671,16 @@ Intro (void)
 	Manner = GET_GAME_STATE (ORZ_MANNER);
 	if (Manner == 2)
 	{
-		CommData.AlienColorMap =
-				SetAbsColorMapIndex (CommData.AlienColorMap, 1);
-
 		// JMS_GFX: Use separate red angry graphics in hires instead of colormap transform.
-		if (IS_HD) {
+		if (IS_HD) 
+		{
 			CommData.AlienFrameRes = ORZ_ANGRY_PMAP_ANIM;
 			CommData.AlienFrame = CaptureDrawable (
-				LoadGraphic (CommData.AlienFrameRes));
+				LoadGraphic (CommData.AlienFrameRes));			
 		}
+		else
+			CommData.AlienColorMap =
+			SetAbsColorMapIndex(CommData.AlienColorMap, 1);
 
 		NumVisits = GET_GAME_STATE (ORZ_VISITS);
 		switch (NumVisits++)

--- a/src/uqm/comm/slyhome/slyhome.c
+++ b/src/uqm/comm/slyhome/slyhome.c
@@ -842,6 +842,9 @@ Intro (void)
 {
 	BYTE NumVisits;
 
+	if (!IsFrameIndexed (CommData.AlienFrame))
+		CommData.AlienAmbientArray[0].AnimFlags |= ANIM_DISABLED;
+
 	if (GET_GAME_STATE (SLYLANDRO_KNOW_BROKEN)
 			&& (NumVisits = GET_GAME_STATE (RECALL_VISITS)) == 0)
 	{

--- a/src/uqm/comm/spahome/spahome.c
+++ b/src/uqm/comm/spahome/spahome.c
@@ -209,130 +209,126 @@ static LOCDATA spahome_desc_hd =
 		{
 			1, /* StartIndex */
 			3, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
+			CIRCULAR_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			0 | (1 << 14), /* BlockMask */
+			0, /* BlockMask */
 		},
 		{
 			4, /* StartIndex */
 			5, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
+			CIRCULAR_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			0 | (1 << 14), /* BlockMask */
+			0, /* BlockMask */
 		},
 		{
 			9, /* StartIndex */
 			4, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
+			CIRCULAR_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 10) | (1 << 11) | (1 << 14), /* BlockMask */
+			(1 << 10) | (1 << 11), /* BlockMask */
 		},
 		{
 			13, /* StartIndex */
 			6, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
+			CIRCULAR_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND / 20, 0, /* RestartRate */
-			(1 << 4) | (1 << 5) | (1 << 14) /* BlockMask */
+			(1 << 4) | (1 << 5), /* BlockMask */
 		},
 		{
 			19, /* StartIndex */
 			3, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 3) | (1 << 5) | (1 << 14), /* BlockMask */
+			(1 << 3) | (1 << 5), /* BlockMask */
 		},
 		{
 			22, /* StartIndex */
 			4, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* RestartRate */
 			(1 << 3) | (1 << 4)
-			| (1 << 10) | (1 << 14), /* BlockMask */
+			| (1 << 10), /* BlockMask */
 		},
 		{
 			26, /* StartIndex */
 			3, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
 			ONE_SECOND * 10, ONE_SECOND * 3, /* RestartRate */
-			(1 << 10) | (1 << 14), /* BlockMask */
+			(1 << 10), /* BlockMask */
 		},
 		{
 			29, /* StartIndex */
 			3, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
 			ONE_SECOND * 10, ONE_SECOND * 3, /* RestartRate */
-			0 | (1 << 14), /* BlockMask */
+			0, /* BlockMask */
 		},
 		{
 			32, /* StartIndex */
 			7, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
+			CIRCULAR_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND / 20, 0, /* RestartRate */
-			(1 << 9) | (1 << 10) | (1 << 14), /* BlockMask */
+			(1 << 9) | (1 << 10), /* BlockMask */
 		},
 		{
 			39, /* StartIndex */
 			3, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 8) | (1 << 10) | (1 << 14), /* BlockMask */
+			(1 << 8) | (1 << 10), /* BlockMask */
 		},
 		{
 			42, /* StartIndex */
 			4, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
 			ONE_SECOND / 30, 0, /* RestartRate */
 			(1 << 8) | (1 << 9)
 			| (1 << 6) | (1 << 2)
-			| (1 << 11) | (1 << 5)
-			 | (1 << 14), /* BlockMask */
+			| (1 << 11) | (1 << 5), /* BlockMask */
 		},
 		{
 			46, /* StartIndex */
 			4, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* RestartRate */
-			(1 << 2) | (1 << 10) | (1 << 14), /* BlockMask */
+			(1 << 2) | (1 << 10), /* BlockMask */
 		},
 		{
 			50, /* StartIndex */
 			6, /* NumFrames */
-			CIRCULAR_ANIM, /* AnimFlags */
+			CIRCULAR_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND / 20, 0, /* RestartRate */
-			(1 << 13) | (1 << 14), /* BlockMask */
+			(1 << 13), /* BlockMask */
 		},
 		{
 			56, /* StartIndex */
 			3, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
+			YOYO_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 12) | (1 << 14), /* BlockMask */
+			(1 << 12), /* BlockMask */
 		},
 		{
 			59, /* StartIndex */
 			11, /* NumFrames */
 			CIRCULAR_ANIM | ONE_SHOT_ANIM
-			| WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
+			| ALPHA_MASK_ANIM | ANIM_DISABLED, /* AnimFlags */
 			ONE_SECOND / 30, 0, /* FrameRate */
 			0, 0,/* RestartRate */
-			(1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) 
-			| (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7) 
-			| (1 << 8) | (1 << 9) | (1 << 10) | (1 << 11) 
-			| (1 << 12) | (1 << 13), /* BlockMask */
+			0, /* BlockMask */
 		},
 	},
 	{ /* AlienTransitionDesc - empty */
@@ -756,21 +752,19 @@ AllianceOffer (RESPONSE_REF R)
 	if (PLAYER_SAID (R, misunderstanding))
 	{
 		NPCPhrase (JUST_MISUNDERSTANDING);
-		if (!IS_HD){
+		if (!IS_HD)
+		{
 			XFormColorMap (GetColorMapAddress (
 					SetAbsColorMapIndex (CommData.AlienColorMap, 1)
 					), ONE_SECOND / 4);
-		} else {
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
-				
+		} 
+		else 
+		{				
 			CommData.AlienFrame = SetAbsFrameIndex 
 				(CommData.AlienFrame, 0);
-				
-			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
+			SetUpAlphaAnimation (100, 0, 14);
+			RunOneTimeSequence (14, 0);
+			SwitchSequences (TRUE);
 		}
 
 		SET_GAME_STATE (SPATHI_MANNER, 3);
@@ -953,19 +947,11 @@ SpathiCouncil (RESPONSE_REF R)
 		} 
 		else
 		{
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations;
-
 			CommData.AlienFrame = SetAbsFrameIndex
-			(CommData.AlienFrame, 59);
-
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
-
-			CommData.AlienFrame = SetAbsFrameIndex 
 				(CommData.AlienFrame, 0);
-
-			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
+			SetUpAlphaAnimation (100, 0, 14);
+			RunOneTimeSequence (14, 0);
+			SwitchSequences (TRUE);
 		}
 
 		SET_GAME_STATE (KNOW_SPATHI_PASSWORD, 1);
@@ -1102,9 +1088,9 @@ Intro (void)
 {
 	BYTE Manner;
 
-	if (IS_HD)
-		CommData.AlienFrame = SetAbsFrameIndex 
-			(CommData.AlienFrame, 59);
+	if (IS_HD)	
+		CommData.AlienFrame = SetAbsFrameIndex
+		(CommData.AlienFrame, 59);
 
 	Manner = GET_GAME_STATE (SPATHI_MANNER);
 	if (Manner == 2)
@@ -1121,39 +1107,29 @@ Intro (void)
 	}
 	else if (CheckAlliance (SPATHI_SHIP) == GOOD_GUY)
 	{
-		if (!IS_HD) {
+		if (!IS_HD)
 			CommData.AlienColorMap =
  				SetAbsColorMapIndex (CommData.AlienColorMap, 1);
-		} else {
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations - 1;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
+		else
+		{
+			SwitchSequences (TRUE);
 			
 			CommData.AlienFrame = SetAbsFrameIndex 
 				(CommData.AlienFrame, 0);
-				
-			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
 		}
 		SpathiAllies ((RESPONSE_REF)0);
 	}
 	else if (GET_GAME_STATE (SPATHI_PARTY))
 	{
-		if (!IS_HD){
+		if (!IS_HD)
 			CommData.AlienColorMap =
  				SetAbsColorMapIndex (CommData.AlienColorMap, 1);
-		} else {
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations - 1;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
-				
+		else 
+		{
+			SwitchSequences (TRUE);
+
 			CommData.AlienFrame = SetAbsFrameIndex 
 				(CommData.AlienFrame, 0);
-				
-			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
 		};
 		SpathiParty ((RESPONSE_REF)0);
 	}
@@ -1161,20 +1137,15 @@ Intro (void)
 	{
 		if (GET_GAME_STATE (LIED_ABOUT_CREATURES) < 2)
 		{
-			if (!IS_HD) {
+			if (!IS_HD)
 				CommData.AlienColorMap =
  					SetAbsColorMapIndex (CommData.AlienColorMap, 1);
-			} else {
-				COUNT i = 0;
-				COUNT limit = CommData.NumAnimations - 1;
-			
-				for (i = 0; i < limit; i++)
-					CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
-				
+			else 
+			{
+				SwitchSequences (TRUE);
+
 				CommData.AlienFrame = SetAbsFrameIndex 
 					(CommData.AlienFrame, 0);
-				
-				CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
 			}
 			SpathiQuest ((RESPONSE_REF)0);
 		}
@@ -1188,20 +1159,15 @@ Intro (void)
 	}
 	else if (GET_GAME_STATE (KNOW_SPATHI_QUEST))
 	{
-		if (!IS_HD) {
+		if (!IS_HD)
 			CommData.AlienColorMap =
- 				SetAbsColorMapIndex (CommData.AlienColorMap, 1);
-		} else {
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations - 1;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
+ 				SetAbsColorMapIndex (CommData.AlienColorMap, 1); 
+		else 
+		{
+			SwitchSequences (TRUE);
 				
 			CommData.AlienFrame = SetAbsFrameIndex 
 				(CommData.AlienFrame, 0);
-				
-			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
 		}
 		LearnQuest ((RESPONSE_REF)0);
 	}
@@ -1209,20 +1175,15 @@ Intro (void)
 			&& (GET_GAME_STATE (FOUND_PLUTO_SPATHI)
 			|| GET_GAME_STATE (SPATHI_HOME_VISITS) != 7))
 	{
-		if (!IS_HD) {
+		if (!IS_HD) 
 			CommData.AlienColorMap =
  				SetAbsColorMapIndex (CommData.AlienColorMap, 1);
-		} else {
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations - 1;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
+		else 
+		{
+			SwitchSequences (TRUE);
 				
 			CommData.AlienFrame = SetAbsFrameIndex 
 				(CommData.AlienFrame, 0);
-				
-			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
 		}
 		SpathiCouncil ((RESPONSE_REF)0);
 	}
@@ -1280,15 +1241,6 @@ init_spahome_comm ()
 	spahome_desc.AlienAltSongRes = SPAHOME_MUSIC;
 	spahome_desc.AlienSongFlags |= LDASF_USE_ALTERNATE;
 
-	if (IS_HD) {
-		COUNT i;
-		COUNT limit = spahome_desc.NumAnimations;
-	
-		for (i = 0; i < limit; i++)
-			spahome_desc.AlienAmbientArray[i].AnimFlags |= ANIM_DISABLED;
-			
-		spahome_desc.AlienTalkDesc.AnimFlags |= PAUSE_TALKING;
-	}
 
 	if (GET_GAME_STATE (SPATHI_MANNER) == 3)
 	{

--- a/src/uqm/comm/syreen/syreenc.c
+++ b/src/uqm/comm/syreen/syreenc.c
@@ -211,7 +211,7 @@ static LOCDATA syreen_desc_hd =
 	NULL_RESOURCE, /* AlienAltSong */
 	0, /* AlienSongFlags */
 	SYREEN_CONVERSATION_PHRASES, /* PlayerPhrases */
-	17, /* NumAnimations */
+	16, /* NumAnimations */
 	{ /* AlienAmbientArray (ambient animations) */
 		{
 			5, /* StartIndex */
@@ -337,23 +337,12 @@ static LOCDATA syreen_desc_hd =
 		},
 		{
 			51, /* StartIndex */
-			13, /* NumFrames */
-			CIRCULAR_ANIM | ONE_SHOT_ANIM 
-				| WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
-			ONE_SECOND / 15, 0, /* FrameRate */
+			21, /* NumFrames */
+			CIRCULAR_ANIM | ONE_SHOT_ANIM
+			| ALPHA_MASK_ANIM | ANIM_DISABLED, /* AnimFlags */
+			ONE_SECOND / 30, 0, /* FrameRate */
 			0, 0,/* RestartRate */
 			0, /* BlockMask */
-		},
-		{
-			64, /* StartIndex */
-			13, /* NumFrames */
-			CIRCULAR_ANIM | ONE_SHOT_ANIM
-				| WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
-			ONE_SECOND / 15, 0, /* FrameRate */
-			0, 0,/* RestartRate */
-			(1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) |
-			(1 << 4) | (1 << 5) | (1 << 6) | (1 << 7) |
-			(1 << 8) | (1 << 10) | (1 << 11), /* BlockMask */
 		},
 	},
 	{ /* AlienTransitionDesc */
@@ -433,7 +422,8 @@ FriendlyExit (RESPONSE_REF R)
 		SetCommDarkMode (FALSE);
 		RedrawSISComWindow ();
 
-		if (!IS_HD) {
+		if (!IS_HD)
+		{
 			XFormColorMap (GetColorMapAddress (
  				SetAbsColorMapIndex (CommData.AlienColorMap, 0)
  				), ONE_SECOND / 2);
@@ -443,22 +433,14 @@ FriendlyExit (RESPONSE_REF R)
 		} 
 		else 
 		{
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations;
-			
-			CommData.AlienAmbientArray[limit-1].AnimFlags &= ~ANIM_DISABLED;
 			CommData.AlienFrame = SetAbsFrameIndex
 				(CommData.AlienFrame, 0);
-			
+			SwitchSequences (TRUE);
 			CommData.AlienTalkDesc.AnimFlags &= ~PAUSE_TALKING;
+
 			FadeScreen (FadeAllToColor, ONE_SECOND / 2);
 			BlockTalkingAnim (1, 2); // Several hours later block (New)
 			AlienTalkSegue ((COUNT)~0);
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags &= ~ANIM_DISABLED;
-			
-			CommData.AlienAmbientArray[limit-2].AnimFlags |= ANIM_DISABLED;
 		}
 
 		SET_GAME_STATE (PLAYER_HAD_SEX, 1);
@@ -552,24 +534,23 @@ Foreplay (RESPONSE_REF R)
 		CommData.AlienTextFColor = BUILD_COLOR_RGBA (85, 255, 255, 0);
 		SetCommDarkMode (TRUE);
 
-		if (!IS_HD) {
+		if (!IS_HD) 
+		{
 			XFormColorMap (GetColorMapAddress (
 					SetAbsColorMapIndex (CommData.AlienColorMap, 1)
 					), ONE_SECOND);
 		} 
 		else 
 		{
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations - 2;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags |= ANIM_DISABLED;
-				
-			CommData.AlienAmbientArray[limit].AnimFlags &= ~ANIM_DISABLED;
-			CommData.AlienFrame = SetAbsFrameIndex 
-				(CommData.AlienFrame, 63);
-				
-			CommData.AlienTalkDesc.AnimFlags |= PAUSE_TALKING;
+			SetUpAlphaAnimation (0, 100, 15);
+			RunOneTimeSequence (15, STOP_ALL_AFTER);
+		/*	if (!EXTENDED)
+			{
+				CommData.AlienFrame = SetAbsFrameIndex
+					(CommData.AlienFrame, 63);
+				CommData.AlienTalkDesc.AnimFlags |= PAUSE_TALKING;
+				RunOneTimeSequence(16, 0);
+			}*/ // For future ideas maybe
 		}
 	
 		AlienTalkSegue ((COUNT)~0);			

--- a/src/uqm/comm/talkpet/talkpet.c
+++ b/src/uqm/comm/talkpet/talkpet.c
@@ -46,7 +46,7 @@ static LOCDATA talkpet_desc =
 	NULL_RESOURCE, /* AlienAltSong */
 	0, /* AlienSongFlags */
 	TALKING_PET_CONVERSATION_PHRASES, /* PlayerPhrases */
-	17, /* NumAnimations */
+	18, /* NumAnimations */
 	{ /* AlienAmbientArray (ambient animations) */
 		{
 			7, /* StartIndex */
@@ -188,6 +188,15 @@ static LOCDATA talkpet_desc =
 			0, 0, /* RestartRate */
 			0, /* BlockMask */
 		},
+		{	/* Mind control strobe HD (on-demand) */
+			54, /* StartIndex */
+			NUM_STROBES, /* NumFrames */
+			YOYO_ANIM | ONE_SHOT_ANIM
+			| ALPHA_MASK_ANIM | ANIM_DISABLED, /* AnimFlags */
+			ONE_SECOND / (STROBE_RATE * 3), 0, /* FrameRate */
+			0, 0,/* RestartRate */
+			0, /* BlockMask */
+		},
 	},
 	{ /* AlienTransitionDesc */
 		0, /* StartIndex */
@@ -278,7 +287,10 @@ static void
 MindControlStrobe (void)
 {
 	// Enable the one-shot strobe animation
-	CommData.AlienAmbientArray[16].AnimFlags &= ~ANIM_DISABLED;
+	if (IS_HD)
+		CommData.AlienAmbientArray[17].AnimFlags &= ~ANIM_DISABLED;
+	else
+		CommData.AlienAmbientArray[16].AnimFlags &= ~ANIM_DISABLED;
 }
 
 static void

--- a/src/uqm/comm/thradd/thraddc.c
+++ b/src/uqm/comm/thradd/thraddc.c
@@ -52,7 +52,7 @@ static LOCDATA thradd_desc =
 			RANDOM_ANIM, /* AnimFlags */
 			ONE_SECOND / 15, ONE_SECOND / 15, /* FrameRate */
 			ONE_SECOND / 15, ONE_SECOND / 15, /* RestartRate */
-			(1 << 5), /* BlockMask */
+			(1 << 4), /* BlockMask */
 		},
 		{
 			12, /* StartIndex */
@@ -76,15 +76,7 @@ static LOCDATA thradd_desc =
 			YOYO_ANIM, /* AnimFlags */
 			ONE_SECOND / 20, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 5), /* BlockMask */
-		},
-		{// swapped to avoid overdraw 
-			42, /* StartIndex */
-			5, /* NumFrames */
-			YOYO_ANIM, /* AnimFlags */
-			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
-			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 5) | (1 << 6), /* BlockMask */
+			(1 << 4), /* BlockMask */
 		},
 		{
 			30, /* StartIndex */
@@ -93,7 +85,15 @@ static LOCDATA thradd_desc =
 					| WAIT_TALKING, /* AnimFlags */
 			ONE_SECOND / 12, 0, /* FrameRate */
 			ONE_SECOND, ONE_SECOND, /* RestartRate */
-			(1 << 0) | (1 << 3) | (1 << 4),
+			(1 << 0) | (1 << 3) | (1 << 5),
+		},
+		{
+			42, /* StartIndex */
+			5, /* NumFrames */
+			YOYO_ANIM, /* AnimFlags */
+			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
+			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
+			(1 << 4) | (1 << 6), /* BlockMask */
 		},
 		{
 			47, /* StartIndex */
@@ -101,7 +101,7 @@ static LOCDATA thradd_desc =
 			YOYO_ANIM, /* AnimFlags */
 			ONE_SECOND / 10, ONE_SECOND / 30, /* FrameRate */
 			ONE_SECOND, ONE_SECOND * 3, /* RestartRate */
-			(1 << 4), /* BlockMask */
+			(1 << 5), /* BlockMask */
 		},
 		{
 			52, /* StartIndex */

--- a/src/uqm/comm/urquan/urquanc.c
+++ b/src/uqm/comm/urquan/urquanc.c
@@ -102,7 +102,7 @@ static LOCDATA urquan_desc =
 		1, /* StartIndex */
 		2, /* NumFrames */
 		0, /* AnimFlags */
-		ONE_SECOND / 6, 0, /* FrameRate */
+		ONE_SECOND / 30, 0, /* FrameRate */
 		0, 0, /* RestartRate */
 		0, /* BlockMask */
 	},

--- a/src/uqm/comm/vux/vuxc.c
+++ b/src/uqm/comm/vux/vuxc.c
@@ -220,7 +220,7 @@ static LOCDATA vux_desc_hd =
 	NULL_RESOURCE, /* AlienAltSong */
 	0, /* AlienSongFlags */
 	VUX_CONVERSATION_PHRASES, /* PlayerPhrases */
-	18, /* NumAnimations */
+	19, /* NumAnimations */
 	{ /* AlienAmbientArray (ambient animations) */
 		{
 			12, /* StartIndex */
@@ -360,9 +360,19 @@ static LOCDATA vux_desc_hd =
 		},
 		{
 			103, /* StartIndex */
-			13, /* NumFrames */
-			CIRCULAR_ANIM | ONE_SHOT_ANIM | WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
-			ONE_SECOND / 30, 0, /* FrameRate */
+			8, /* NumFrames */
+			CIRCULAR_ANIM | ONE_SHOT_ANIM 
+			| WAIT_TALKING | ANIM_DISABLED, /* AnimFlags */
+			ONE_SECOND / 15, 0, /* FrameRate */
+			0, 0,/* RestartRate */
+			0, /* BlockMask */
+		},
+		{
+			111, /* StartIndex */
+			11, /* NumFrames */
+			CIRCULAR_ANIM | ONE_SHOT_ANIM
+			| ALPHA_MASK_ANIM | ANIM_DISABLED, /* AnimFlags */
+			ONE_SECOND / 40, 0, /* FrameRate */
 			0, 0,/* RestartRate */
 			0, /* BlockMask */
 		},
@@ -381,7 +391,7 @@ static LOCDATA vux_desc_hd =
 		0, /* AnimFlags */
 		ONE_SECOND / 15, 0, /* FrameRate */
 		ONE_SECOND / 12, 0, /* RestartRate */
-		(1 << 18), /* BlockMask */
+		0, /* BlockMask */
 	},
 	NULL, /* AlienNumberSpeech - none */
 	/* Filler for loaded resources */
@@ -404,22 +414,24 @@ CombatIsInevitable (RESPONSE_REF R)
 
 		AlienTalkSegue (1);
 
-		if (!IS_HD) {
+		if (!IS_HD) 
 			XFormColorMap (GetColorMapAddress (
 					SetAbsColorMapIndex (CommData.AlienColorMap, 1)
 					), ONE_SECOND / 4);
-		} else {
-			COUNT i = 0;
-			COUNT limit = CommData.NumAnimations - 1;
-			
-			for (i = 0; i < limit; i++)
-				CommData.AlienAmbientArray[i].AnimFlags |= ANIM_DISABLED;
-				
-			CommData.AlienAmbientArray[limit].AnimFlags &= ~ANIM_DISABLED;
-			CommData.AlienFrame = SetAbsFrameIndex 
-				(CommData.AlienFrame, 115);
-				
-			CommData.AlienTalkDesc.AnimFlags |= PAUSE_TALKING;
+		else 
+		{
+			if (!EXTENDED)
+			{
+				CommData.AlienFrame = SetAbsFrameIndex
+					(CommData.AlienFrame, 110);
+				CommData.AlienTalkDesc.AnimFlags |= PAUSE_TALKING;
+				RunOneTimeSequence (17, 0);				
+			}
+			else
+			{
+				SetUpAlphaAnimation (0, 100, 18);
+				RunOneTimeSequence (18, STOP_ALL_AFTER);
+			}
 		}
 
 		AlienTalkSegue ((COUNT)~0);

--- a/src/uqm/commanim.h
+++ b/src/uqm/commanim.h
@@ -63,6 +63,19 @@ extern "C" {
 		// Kr (needed for blocking animations that are WAIT_TALKING even
 		// if talking itself is stopped. Used only in PS-DOS style scrolling)
 
+#define RESTART_ALL_AFTER (1 << 10)
+#define STOP_ALL_AFTER (1 << 11)
+		// Kruzen: Needed for ONE_SHOT_ANIM in HD to define - should we restart
+		// other ambient animations or no
+
+#define IMMUME_TO_RESTART (1 << 12)
+#define IMMUME_TO_STOP (1 << 13)
+		// Kruzen: Some animations needed to be handled individually
+
+#define ALPHA_MASK_ANIM (1 << 14)
+		// Kruzen: New type of animations: Draw transparent frames
+		// on top of all (sets fullRedraw to TRUE
+
 #define FAST_STOP_AT_TALK_START (TALK_DONE) // JMS: If there's a very loooong animation, it can be forced to stop when talking with this.
 // (otherwise there'll be nasty, unwanted pauses in the conversation.) 
 
@@ -71,6 +84,8 @@ extern "C" {
 #define ONE_SHOT_ANIM  TALK_INTRO
 		// Set in AlienAmbientArray for animations that should be
 		// disabled after they run once.
+
+#define BLOCK_ALL_BEFORE_ME(m) ((1 << m) - 1)
 
 typedef struct
 {
@@ -143,6 +158,9 @@ extern BOOLEAN DrawAlienFrame (SEQUENCE *pSeq, COUNT Num, BOOLEAN fullRedraw);
 extern void InitCommAnimations (void);
 extern BOOLEAN ProcessCommAnimations (BOOLEAN fullRedraw, BOOLEAN paused);
 extern void ShutYourMouth (void);
+extern void SwitchSequences (BOOLEAN enableAll);
+extern void RunOneTimeSequence (COUNT animIndex, COUNT flags);
+extern void SetUpAlphaAnimation (SWORD startPersentage, SWORD endPersentage, COUNT animIndex);
 
 #if defined(__cplusplus)
 }

--- a/src/uqm/encount.c
+++ b/src/uqm/encount.c
@@ -736,7 +736,10 @@ UninitEncounter (void)
 									tempR.corner.x += 244;
 									tempR.corner.y += 140;
 									tempR.extent = (EXTENT){ 312, 96 };
-									
+									// TODO: make this frame expandable
+									// depending on text width
+									// could be required for another language
+									// 
 									// Now that we have the size and
 									// placement of the rectangle,
 									// let's store it.
@@ -910,6 +913,8 @@ UninitEncounter (void)
 				ships_killed = THRADDASH_BODY_THRESHOLD;
 			SET_GAME_STATE (THRADDASH_BODY_COUNT, ships_killed);
 		}
+
+		DestroyDrawable (ReleaseDrawable (saveFrame.frame));
 	}
 ExitUninitEncounter:
 

--- a/src/uqm/planets/lander.c
+++ b/src/uqm/planets/lander.c
@@ -1734,6 +1734,7 @@ InitPlanetSide (POINT pt)
 	if (isPC (optSuperPC))
 	{
 		SetContext (RadarContext);
+		SetContextBackGroundColor (BLACK_COLOR);
 		ClearSISRect (CLEAR_SIS_RADAR);
 		MapSurface = MAKE_EXTENT (RADAR_WIDTH, RADAR_HEIGHT);
 


### PR DESCRIPTION
- Reworked comm frame drawing.
- Adjusted some races comm code. 
- HD transparent frame animations. 
- Fixed talking lock persist through saves. 
- Fixed green background of PC-lander surface frame. 
- Fixed text black outline on salvage screen. Also properly removed from memory.