### PR TITLE
Several fixes and improvements

### DIFF
--- a/src/uqm/encount.c
+++ b/src/uqm/encount.c
@@ -302,7 +302,8 @@ InitEncounter (void)
 
 	MR = LoadMusic (REDALERT_MUSIC);
 	PlayMusic (MR, FALSE, 1);
-	SegueFrame = CaptureDrawable (LoadGraphic (SEGUE_PMAP_ANIM));
+	SegueFrame = optNebulae ? CreateStarBackGround (TRUE) :
+			CaptureDrawable (LoadGraphic (SEGUE_PMAP_ANIM));
 	WaitForSoundEnd (TFBSOUND_WAIT_ALL);
 	StopMusic ();
 	DestroyMusic (MR);
@@ -313,7 +314,7 @@ InitEncounter (void)
 	
 	SetContextBackGroundColor (BLACK_COLOR);
 	ClearDrawable ();
-	s.frame = optNebulae ? CreateStarBackGround(TRUE) : SegueFrame;
+	s.frame = SegueFrame;
 	DrawStamp (&s);
 
 //    t.baseline.x = SIS_SCREEN_WIDTH >> 1;

--- a/src/uqm/ipdisp.c
+++ b/src/uqm/ipdisp.c
@@ -35,6 +35,7 @@
 
 BOOLEAN legacySave;
 BYTE GTFO = 0;
+extern FRAME SpaceJunkFrame;
 
 void
 NotifyOthers (COUNT which_race, BYTE target_loc)
@@ -707,8 +708,9 @@ spawn_ip_group (IP_GROUP *GroupPtr)
 
 		SetUpElement (IPSHIPElementPtr);
 		IPSHIPElementPtr->IntersectControl.IntersectStamp.frame =
-				DecFrameIndex (stars_in_space);
-
+				(IS_HD ? SetAbsFrameIndex (SpaceJunkFrame, 24) :
+					DecFrameIndex (stars_in_space));
+		
 		UnlockElement (hIPSHIPElement);
 
 		PutElement (hIPSHIPElement);


### PR DESCRIPTION
- Fixed: Memory leak with SegueFrame if nebula was on (generated star frame wasn't being destroyed)
- Fixed: Orbital backframe generated incorrectly if entering orbit of slave shield world from Load Menu
- Fixed: 3DO slave shield throb frame rate (now in SD opacity changes every other frame, and in HD every 4th to compensate generally higher framerate)
- Changed: 3DO spheres with sphere tint on and 3DO scan now uses ADDITIVE blend instead of alpha (more authentic)
- Changed: IP battle groups now use HD orbit dot (spacejunkframe 24) as intersect frame (was 1 pixel as in SD), so their collision frame was enlarged