### PR TITLE
Initial code for smooth captain animations

### DIFF
--- a/src/uqm/init.c
+++ b/src/uqm/init.c
@@ -129,7 +129,7 @@ InitSpace (void)
 
 		misc_in_space = CaptureDrawable (LoadGraphic (STARMISK_MASK_PMAP_ANIM));
 
-		if(IS_HD)
+		if (IS_HD)
 		{
 			StarPoints = CaptureDrawable (LoadGraphic (STARPOINT_MASK_PMAP_ANIM));
 			if (StarPoints == NULL)

--- a/src/uqm/misc.c
+++ b/src/uqm/misc.c
@@ -47,32 +47,47 @@ spawn_planet (void)
 		LockElement (hPlanetElement, &PlanetElementPtr);
 		PlanetElementPtr->playerNr = NEUTRAL_PLAYER_NUM;
 		PlanetElementPtr->hit_points = 200;
-		PlanetElementPtr->state_flags =
-				optMeleeObstacles && !isNetwork ()
-					? DISAPPEARING : APPEARING;
+		PlanetElementPtr->state_flags = APPEARING;
 		PlanetElementPtr->life_span = NORMAL_LIFE + 1;
-		SetPrimType (&DisplayArray[PlanetElementPtr->PrimIndex], STAMP_PRIM);
-		PlanetElementPtr->current.image.farray = planet;
-		PlanetElementPtr->current.image.frame =
-				PlanetElementPtr->current.image.farray[0];
-		PlanetElementPtr->collision_func = collision;
-		PlanetElementPtr->postprocess_func =
-				(void (*) (struct element *ElementPtr))CalculateGravity;
-		ZeroVelocityComponents (&PlanetElementPtr->velocity);
-		do
-		{
+		if (optMeleeObstacles && !isNetwork ())
+		{// Invisible planet with cheats
+			PlanetElementPtr->state_flags |= NONSOLID;
+			SetPrimType (&DisplayArray[PlanetElementPtr->PrimIndex], POINT_PRIM);
+			SetPrimColor (&DisplayArray[PlanetElementPtr->PrimIndex],
+					BUILD_COLOR_RGBA (0x00, 0x00, 0x00, 0x00));
 			PlanetElementPtr->current.location.x =
-					WRAP_X (DISPLAY_ALIGN_X (TFB_Random ()));
+						WRAP_X (DISPLAY_ALIGN_X (TFB_Random ()));
 			PlanetElementPtr->current.location.y =
-					WRAP_Y (DISPLAY_ALIGN_Y (TFB_Random ()));
-		} while (CalculateGravity (PlanetElementPtr)
-				|| TimeSpaceMatterConflict (PlanetElementPtr));
+						WRAP_Y (DISPLAY_ALIGN_Y (TFB_Random ()));
+			PlanetElementPtr->collision_func = NULL;
+			PlanetElementPtr->postprocess_func = NULL;
+			ZeroVelocityComponents (&PlanetElementPtr->velocity);
+		}
+		else
+		{
+			SetPrimType (&DisplayArray[PlanetElementPtr->PrimIndex], STAMP_PRIM);
+			PlanetElementPtr->current.image.farray = planet;
+			PlanetElementPtr->current.image.frame =
+					PlanetElementPtr->current.image.farray[0];
+			PlanetElementPtr->collision_func = collision;
+			PlanetElementPtr->postprocess_func =
+					(void (*) (struct element *ElementPtr))CalculateGravity;
+			ZeroVelocityComponents (&PlanetElementPtr->velocity);
+			do
+			{
+				PlanetElementPtr->current.location.x =
+						WRAP_X (DISPLAY_ALIGN_X (TFB_Random ()));
+				PlanetElementPtr->current.location.y =
+						WRAP_Y (DISPLAY_ALIGN_Y (TFB_Random ()));
+			} while (CalculateGravity (PlanetElementPtr)
+					|| TimeSpaceMatterConflict (PlanetElementPtr));
+		}
 		PlanetElementPtr->mass_points = PlanetElementPtr->hit_points;
 		pt = PlanetElementPtr->current.location;
 
-		UnlockElement(hPlanetElement);
+		UnlockElement (hPlanetElement);
 
-		PutElement(hPlanetElement);
+		PutElement (hPlanetElement);
 	}
 	if (EXTENDED && GET_GAME_STATE (URQUAN_PROTECTING_SAMATRA))
 	{	// Works inconsistently because planet is on top star layer

--- a/src/uqm/races.h
+++ b/src/uqm/races.h
@@ -73,6 +73,8 @@ typedef UWORD STATUS_FLAGS;
 #define SHIP_IN_GRAVITY_WELL   (1 << 8)
 #define PLAY_VICTORY_DITTY     (1 << 9)
 
+#define DRAW_ZERO_FRAME LOW_ON_ENERGY
+
 /* These track the old resource package orderings for the ship resource indices */
 typedef enum
 {
@@ -117,6 +119,12 @@ typedef struct captain_stuff
 	FRAME thrust;
 	FRAME weapon;
 	FRAME special;
+	BYTE tl_offset;
+	BYTE tr_offset;
+	BYTE thrust_offset;
+	BYTE weapon_offset;
+	BYTE special_offset;
+	BYTE redraw_flags;
 } CAPTAIN_STUFF;
 
 typedef enum

--- a/src/uqm/races.h
+++ b/src/uqm/races.h
@@ -73,7 +73,8 @@ typedef UWORD STATUS_FLAGS;
 #define SHIP_IN_GRAVITY_WELL   (1 << 8)
 #define PLAY_VICTORY_DITTY     (1 << 9)
 
-#define DRAW_ZERO_FRAME LOW_ON_ENERGY
+#define SHOFIXTI_EXPLOSION	   (1 << 10)
+#define ANDROSYN_COMET_TOGGLE  (1 << 11)
 
 /* These track the old resource package orderings for the ship resource indices */
 typedef enum
@@ -124,7 +125,6 @@ typedef struct captain_stuff
 	BYTE thrust_offset;
 	BYTE weapon_offset;
 	BYTE special_offset;
-	BYTE redraw_flags;
 } CAPTAIN_STUFF;
 
 typedef enum

--- a/src/uqm/setupmenu.c
+++ b/src/uqm/setupmenu.c
@@ -1600,9 +1600,9 @@ GetGlobalOptions (GLOBALOPTS *opts)
 	 * for config.alwaysgl, then overwrite it if it was set previously. */
 	opts->driver = OPTVAL_PURE_IF_POSSIBLE;
 
-	if (res_IsBoolean ("config.alwaysgl"))
+	if (res_IsBoolean("config.alwaysgl"))
 	{
-		if (res_GetBoolean ("config.alwaysgl"))
+		if (res_GetBoolean("config.alwaysgl"))
 		{
 			opts->driver = OPTVAL_ALWAYS_GL;
 		}

--- a/src/uqm/ships/pkunk/pkunk.c
+++ b/src/uqm/ships/pkunk/pkunk.c
@@ -319,6 +319,8 @@ new_pkunk (ELEMENT *ElementPtr)
 	} while (CalculateGravity (ElementPtr)
 			|| TimeSpaceMatterConflict (ElementPtr));
 
+	ZeroVelocityComponents (&ElementPtr->velocity);
+
 	// XXX: Hack: Set hTarget!=0 so that ship_preprocess() does not
 	//   call ship_transition() for us.
 	ElementPtr->hTarget = StarShipPtr->hShip;

--- a/src/uqm/ships/shofixti/shofixti.c
+++ b/src/uqm/ships/shofixti/shofixti.c
@@ -395,6 +395,7 @@ self_destruct (ELEMENT *ElementPtr)
 
 	// Must kill off the remaining crew ourselves
 	DeltaCrew (ElementPtr, -(int)ElementPtr->crew_level);
+	ZeroVelocityComponents (&ElementPtr->velocity);
 
 	ElementPtr->state_flags |= NONSOLID;
 	ElementPtr->life_span = 0;

--- a/src/uqm/ships/shofixti/shofixti.c
+++ b/src/uqm/ships/shofixti/shofixti.c
@@ -425,10 +425,7 @@ shofixti_intelligence (ELEMENT *ShipPtr, EVALUATE_DESC *ObjectsOfConcern,
 		lpWeaponEvalDesc = &ObjectsOfConcern[ENEMY_WEAPON_INDEX];
 		lpShipEvalDesc = &ObjectsOfConcern[ENEMY_SHIP_INDEX];
 		if (StarShipPtr->RaceDescPtr->ship_data.special[0]
-				&& (GetFrameCount (StarShipPtr->RaceDescPtr->ship_data.
-				captain_control.special)
-				- GetFrameIndex (StarShipPtr->RaceDescPtr->ship_data.
-				captain_control.special) > 5
+				&& (StarShipPtr->RaceDescPtr->ship_data.captain_control.special_offset < 4
 				|| (lpShipEvalDesc->ObjectPtr != NULL
 				&& lpShipEvalDesc->which_turn <= 4)
 				|| (lpWeaponEvalDesc->ObjectPtr != NULL
@@ -444,22 +441,32 @@ shofixti_intelligence (ELEMENT *ShipPtr, EVALUATE_DESC *ObjectsOfConcern,
 }
 
 static void
-shofixti_postprocess (ELEMENT *ElementPtr)
+shofixti_preprocess (ELEMENT *ElementPtr)
 {
 	STARSHIP *StarShipPtr;
 
 	GetElementStarShip (ElementPtr, &StarShipPtr);
 	if ((StarShipPtr->cur_status_flags
-			^ StarShipPtr->old_status_flags) & SPECIAL)
+			^ StarShipPtr->old_status_flags) & SPECIAL &&
+			!(StarShipPtr->cur_status_flags & SPECIAL))
 	{
-		StarShipPtr->RaceDescPtr->ship_data.captain_control.special =
-				IncFrameIndex (StarShipPtr->RaceDescPtr->ship_data.
-				captain_control.special);
-		if (GetFrameCount (StarShipPtr->RaceDescPtr->ship_data.
-				captain_control.special)
-				- GetFrameIndex (StarShipPtr->RaceDescPtr->ship_data.
-				captain_control.special) == 3)
-			self_destruct (ElementPtr);
+		if (!(StarShipPtr->RaceDescPtr->ship_data.captain_control.special_offset & 1))
+			StarShipPtr->RaceDescPtr->ship_data.captain_control.special_offset++;
+		else
+			StarShipPtr->RaceDescPtr->ship_data.captain_control.special_offset += 2;
+	}
+}
+
+static void
+shofixti_postprocess (ELEMENT *ElementPtr)
+{
+	STARSHIP *StarShipPtr;
+
+	GetElementStarShip (ElementPtr, &StarShipPtr);
+	if (StarShipPtr->RaceDescPtr->ship_data.captain_control.special_offset == 5)
+	{
+		self_destruct (ElementPtr);
+		StarShipPtr->cur_status_flags |= SHOFIXTI_EXPLOSION;
 	}
 }
 
@@ -476,6 +483,7 @@ init_shofixti (void)
 		shofixti_desc.cyborg_control.WeaponRange = MISSILE_SPEED_HD * MISSILE_LIFE;
 	}
 
+	shofixti_desc.preprocess_func = shofixti_preprocess;
 	shofixti_desc.postprocess_func = shofixti_postprocess;
 	shofixti_desc.init_weapon_func = initialize_standard_missile;
 	shofixti_desc.cyborg_control.intelligence_func = shofixti_intelligence;

--- a/src/uqm/shipstat.c
+++ b/src/uqm/shipstat.c
@@ -159,6 +159,17 @@ InitShipStatus (SHIP_INFO *SIPtr, STARSHIP *StarShipPtr, RECT *pClipRect, BOOLEA
 	{
 		assert (StarShipPtr->playerNr >= 0);
 		y = status_y_offsets[StarShipPtr->playerNr];
+
+		{
+			CAPTAIN_STUFF* cs = &StarShipPtr->RaceDescPtr->ship_data.captain_control;
+
+			cs->tl_offset = 0;
+			cs->tr_offset = 0;
+			cs->thrust_offset = 0;
+			cs->weapon_offset = 0;
+			cs->special_offset = 0;
+			cs->redraw_flags = 0;
+		}
 	}
 
 	OldContext = SetContext (StatusContext);

--- a/src/uqm/shipstat.c
+++ b/src/uqm/shipstat.c
@@ -161,14 +161,13 @@ InitShipStatus (SHIP_INFO *SIPtr, STARSHIP *StarShipPtr, RECT *pClipRect, BOOLEA
 		y = status_y_offsets[StarShipPtr->playerNr];
 
 		{
-			CAPTAIN_STUFF* cs = &StarShipPtr->RaceDescPtr->ship_data.captain_control;
+			CAPTAIN_STUFF *cs = &StarShipPtr->RaceDescPtr->ship_data.captain_control;
 
 			cs->tl_offset = 0;
 			cs->tr_offset = 0;
 			cs->thrust_offset = 0;
 			cs->weapon_offset = 0;
 			cs->special_offset = 0;
-			cs->redraw_flags = 0;
 		}
 	}
 

--- a/src/uqm/status.c
+++ b/src/uqm/status.c
@@ -44,21 +44,22 @@ InitStatusOffsets (void)
 }
 
 bool
-animIsInTransition (CAPTAIN_STUFF* CSPtr)
+animIsInTransition (CAPTAIN_STUFF *CSPtr)
 {
-	return (CSPtr->thrust_offset == 1) ||
-			(CSPtr->weapon_offset == 1) ||
-			(CSPtr->special_offset == 1) ||
-			(CSPtr->tl_offset == 1) ||
-			(CSPtr->tr_offset == 1);
+	return (CSPtr->thrust_offset & 1) ||
+			(CSPtr->weapon_offset & 1) ||
+			(CSPtr->special_offset & 1) ||
+			(CSPtr->tl_offset & 1) ||
+			(CSPtr->tr_offset & 1);
 }
 
-static void
+static BYTE
 CalculateAnimOffsets (CAPTAIN_STUFF* CSPtr, 
-		STATUS_FLAGS delta_status_flags, STATUS_FLAGS cur_status_flags,
-		BYTE *redraw_flag)
+		STATUS_FLAGS delta_status_flags, STATUS_FLAGS cur_status_flags)
 {
-	if (delta_status_flags & LEFT || CSPtr->tl_offset == 1)
+	BYTE redraw_flag = 0;
+
+	if (delta_status_flags & LEFT || CSPtr->tl_offset & 1)
 	{
 		if (!(delta_status_flags & RIGHT))
 		{
@@ -69,24 +70,24 @@ CalculateAnimOffsets (CAPTAIN_STUFF* CSPtr,
 			else
 				CSPtr->tl_offset--;
 
-			*redraw_flag |= LEFT;
+			redraw_flag |= LEFT;
 		}
 		else if (cur_status_flags & RIGHT)
 		{
 			CSPtr->tl_offset = 0;
 			CSPtr->tr_offset = 1;
 
-			*redraw_flag |= (RIGHT | DRAW_ZERO_FRAME);
+			redraw_flag |= RIGHT;
 		}
 		else
 		{
 			CSPtr->tr_offset = 0;
 			CSPtr->tl_offset = 1;
 
-			*redraw_flag |= (LEFT | DRAW_ZERO_FRAME);
+			redraw_flag |= LEFT;
 		}
 	}
-	else if (delta_status_flags & RIGHT || CSPtr->tr_offset == 1)
+	else if (delta_status_flags & RIGHT || CSPtr->tr_offset & 1)
 	{
 		CSPtr->tl_offset = 0;
 
@@ -95,36 +96,40 @@ CalculateAnimOffsets (CAPTAIN_STUFF* CSPtr,
 		else
 			CSPtr->tr_offset--;
 
-		*redraw_flag |= RIGHT;
+		redraw_flag |= RIGHT;
 	}
 
-	if (delta_status_flags & THRUST || CSPtr->thrust_offset == 1)
+	if (delta_status_flags & THRUST || CSPtr->thrust_offset & 1)
 	{
 		if (cur_status_flags & THRUST)
 			CSPtr->thrust_offset++;
 		else
 			CSPtr->thrust_offset--;
 
-		*redraw_flag |= THRUST;
+		redraw_flag |= THRUST;
 	}
-	if (delta_status_flags & WEAPON || CSPtr->weapon_offset == 1)
+
+	if (delta_status_flags & WEAPON || CSPtr->weapon_offset & 1)
 	{
 		if (cur_status_flags & WEAPON)
 			CSPtr->weapon_offset++;
 		else
 			CSPtr->weapon_offset--;
 
-		*redraw_flag |= WEAPON;
+		redraw_flag |= WEAPON;
 	}
-	if (delta_status_flags & SPECIAL || CSPtr->special_offset == 1)
+
+	if (delta_status_flags & SPECIAL || CSPtr->special_offset & 1)
 	{
 		if (cur_status_flags & SPECIAL)
 			CSPtr->special_offset++;
 		else
 			CSPtr->special_offset--;
 
-		*redraw_flag |= SPECIAL;
+		redraw_flag |= SPECIAL;
 	}
+
+	return redraw_flag;
 }
 
 static void
@@ -136,33 +141,33 @@ DrawCaptainWindowAnimation (CAPTAIN_STUFF* CSPtr, COORD y,
 	Stamp.origin.x = CAPTAIN_XOFFS;
 	Stamp.origin.y = y + CAPTAIN_YOFFS;
 
-	if (redraw_flag & (LEFT | RIGHT))
+	if (redraw_flag & LEFT)
 	{
-		if (redraw_flag & DRAW_ZERO_FRAME)
-		{// draw neutral frame in case of 1-frame direction switch
-			if (redraw_flag & RIGHT)
-			{
-				Stamp.frame = SetRelFrameIndex (CSPtr->turn, 3);
-				DrawStamp (&Stamp);
-				Stamp.frame = DecFrameIndex (Stamp.frame);
-			}
-			else if (redraw_flag & LEFT)
-			{
-				Stamp.frame = SetRelFrameIndex (CSPtr->turn, 1);
-				DrawStamp (&Stamp);
-				Stamp.frame = IncFrameIndex (Stamp.frame);
-			}			
-			DrawStamp (&Stamp);
-		}
+		BYTE i;
 
-		if (redraw_flag & LEFT)
+		Stamp.frame = SetRelFrameIndex (CSPtr->turn, 1);
+		DrawStamp (&Stamp);
+		Stamp.frame = IncFrameIndex (Stamp.frame);
+		DrawStamp (&Stamp);
+
+		for (i = 0; i < CSPtr->tl_offset; i++)
 		{
-			Stamp.frame = SetRelFrameIndex (CSPtr->turn, 2 + CSPtr->tl_offset);
+			Stamp.frame = IncFrameIndex (Stamp.frame);
 			DrawStamp (&Stamp);
 		}
-		else if (redraw_flag & RIGHT)
+	}
+	else if (redraw_flag & RIGHT)
+	{
+		BYTE i;
+
+		Stamp.frame = SetRelFrameIndex (CSPtr->turn, 3);
+		DrawStamp (&Stamp);
+		Stamp.frame = DecFrameIndex (Stamp.frame);
+		DrawStamp (&Stamp);
+
+		for (i = 0; i < CSPtr->tr_offset; i++)
 		{
-			Stamp.frame = SetRelFrameIndex (CSPtr->turn, 2 - CSPtr->tr_offset);
+			Stamp.frame = DecFrameIndex (Stamp.frame);
 			DrawStamp (&Stamp);
 		}
 	}
@@ -184,6 +189,19 @@ DrawCaptainWindowAnimation (CAPTAIN_STUFF* CSPtr, COORD y,
 		Stamp.frame = SetRelFrameIndex (CSPtr->special, CSPtr->special_offset);
 		DrawStamp (&Stamp);
 	}
+}
+
+static void
+DrawCaptainWindowFrame (FRAME fr, COORD y)
+{
+	STAMP Stamp;
+
+	Stamp.origin.x = CAPTAIN_XOFFS;
+	Stamp.origin.y = y + CAPTAIN_YOFFS;
+
+	Stamp.frame = fr;
+
+	DrawStamp (&Stamp);
 }
 
 static void
@@ -545,11 +563,11 @@ PreProcessStatus (ELEMENT *ShipPtr)
 		if (old_status_flags || animIsInTransition (CSPtr))
 		{
 			assert (StarShipPtr->playerNr >= 0);
-			CalculateAnimOffsets (CSPtr, old_status_flags, cur_status_flags, 
-					&redraw_flags);
-		}
+			redraw_flags = CalculateAnimOffsets (CSPtr, old_status_flags, cur_status_flags);
 
-		CSPtr->redraw_flags = redraw_flags;
+			if (redraw_flags)
+				DrawCaptainWindowAnimation (CSPtr, status_y_offsets[StarShipPtr->playerNr], redraw_flags);
+		}
 	}
 }
 
@@ -564,8 +582,7 @@ PostProcessStatus (ELEMENT *ShipPtr)
 	{	// All except Sa-Matra, no captain's window there
 		COORD y;
 		STATUS_FLAGS cur_status_flags, old_status_flags;
-		CAPTAIN_STUFF *CSPtr;
-		BYTE redraw_flags;
+		
 
 		cur_status_flags = StarShipPtr->cur_status_flags;
 
@@ -577,80 +594,95 @@ PostProcessStatus (ELEMENT *ShipPtr)
 			StarShipPtr->cur_status_flags &=
 					~(LEFT | RIGHT | THRUST | WEAPON | SPECIAL);
 
-			if (StarShipPtr->RaceDescPtr->ship_info.crew_level == 0)
-			{
+			if (StarShipPtr->RaceDescPtr->ship_info.crew_level == 0 &&
+					ShipPtr->state_flags & FINITE_LIFE)
+			{// Kruzen: FINITE_LIFE check was added in case if crew-level == 0
+			 // Is triggered by the ship itself (shofixti glory device) and
+			 // avoiding drawing black area
 				BYTE i, j;
 				Color c;
 				RECT r;
 
 				i = (BYTE)(NUM_EXPLOSION_FRAMES * 3 - 1) - ShipPtr->life_span;
-				if (i <= 4)
-				{
-					static const Color flash_tab0[] =
-					{
-						BUILD_COLOR (MAKE_RGB15_INIT (0x0F, 0x00, 0x00), 0x2D),
-						BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x19, 0x19), 0x24),
-						BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x11, 0x00), 0x7B),
-						BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1C, 0x00), 0x78),
-						BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1F, 0x1F), 0x0F),
-					};
 
-					c = flash_tab0[i];
-					r.corner.x = CAPTAIN_XOFFS;
-					r.corner.y = y + CAPTAIN_YOFFS;
-					r.extent.width = CAPTAIN_WIDTH;
-					r.extent.height = CAPTAIN_HEIGHT;
+				if (cur_status_flags & SHOFIXTI_EXPLOSION && i == 0)
+				{// Special case: Instead of first orange rectangle we will draw the last
+				 // frame from captain avatars (used for shofixti glory device)
+					CAPTAIN_STUFF *CSPtr;
+					CSPtr = &StarShipPtr->RaceDescPtr->ship_data.captain_control;
+
+					cur_status_flags &= ~SHOFIXTI_EXPLOSION;
+					DrawCaptainWindowFrame (DecFrameIndex (CSPtr->background), y);
 				}
 				else
 				{
-					SetContextForeGroundColor (BLACK_COLOR);
-					i -= 5;
-					if (i <= 14)
+					if (i <= 4)
 					{
-						static const Color flash_tab1[] =
+						static const Color flash_tab0[] =
 						{
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1E, 0x1F, 0x12), 0x70),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1F, 0x0A), 0x0E),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1F, 0x00), 0x71),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1C, 0x00), 0x78),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x18, 0x00), 0x79),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x15, 0x00), 0x7A),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x11, 0x00), 0x7B),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x0E, 0x00), 0x7C),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x0A, 0x00), 0x7D),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x07, 0x00), 0x7E),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x03, 0x00), 0x7F),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x1B, 0x00, 0x00), 0x2A),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x17, 0x00, 0x00), 0x2B),
-							BUILD_COLOR (MAKE_RGB15_INIT (0x13, 0x00, 0x00), 0x2C),
 							BUILD_COLOR (MAKE_RGB15_INIT (0x0F, 0x00, 0x00), 0x2D),
+							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x19, 0x19), 0x24),
+							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x11, 0x00), 0x7B),
+							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1C, 0x00), 0x78),
+							BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1F, 0x1F), 0x0F),
 						};
 
-						c = flash_tab1[i];
-						r.corner.x = CAPTAIN_XOFFS + RES_SCALE (i);
-						r.corner.y = y + CAPTAIN_YOFFS + RES_SCALE (i);
-						r.extent.width = CAPTAIN_WIDTH - RES_SCALE ((i << 1));
-						r.extent.height = CAPTAIN_HEIGHT - RES_SCALE ((i << 1));
-
-						if (r.extent.height == RES_SCALE (2))
-							r.extent.height += RES_SCALE (1);
-
-						for (j = 0; j < RES_SCALE (1); j++)
-						{	
-							DrawRectangle (&r, FALSE);
-							++r.corner.x;
-							++r.corner.y;
-							r.extent.width -= 2;
-							r.extent.height -= 2;
-						}
+						c = flash_tab0[i];
+						r.corner.x = CAPTAIN_XOFFS;
+						r.corner.y = y + CAPTAIN_YOFFS;
+						r.extent.width = CAPTAIN_WIDTH;
+						r.extent.height = CAPTAIN_HEIGHT;
 					}
-					else if ((i -= 15) <= 4)
+					else
 					{
-						r.corner.y = y + (CAPTAIN_YOFFS + RES_SCALE (15)); 
-						r.extent.width = RES_SCALE (i + 1); 
-						r.extent.height = RES_SCALE (1);
-						switch (i)
+						SetContextForeGroundColor (BLACK_COLOR);
+						i -= 5;
+						if (i <= 14)
 						{
+							static const Color flash_tab1[] =
+							{
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1E, 0x1F, 0x12), 0x70),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1F, 0x0A), 0x0E),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1F, 0x00), 0x71),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x1C, 0x00), 0x78),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x18, 0x00), 0x79),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x15, 0x00), 0x7A),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x11, 0x00), 0x7B),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x0E, 0x00), 0x7C),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x0A, 0x00), 0x7D),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x07, 0x00), 0x7E),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1F, 0x03, 0x00), 0x7F),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x1B, 0x00, 0x00), 0x2A),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x17, 0x00, 0x00), 0x2B),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x13, 0x00, 0x00), 0x2C),
+								BUILD_COLOR (MAKE_RGB15_INIT (0x0F, 0x00, 0x00), 0x2D),
+							};
+
+							c = flash_tab1[i];
+							r.corner.x = CAPTAIN_XOFFS + RES_SCALE (i);
+							r.corner.y = y + CAPTAIN_YOFFS + RES_SCALE (i);
+							r.extent.width = CAPTAIN_WIDTH - RES_SCALE ((i << 1));
+							r.extent.height = CAPTAIN_HEIGHT - RES_SCALE ((i << 1));
+
+							if (r.extent.height == RES_SCALE (2))
+								r.extent.height += RES_SCALE (1);
+
+							for (j = 0; j < RES_SCALE (1); j++)
+							{
+								DrawRectangle (&r, FALSE);
+								++r.corner.x;
+								++r.corner.y;
+								r.extent.width -= 2;
+								r.extent.height -= 2;
+							}
+						}
+						else if ((i -= 15) <= 4)
+						{
+							r.corner.y = y + (CAPTAIN_YOFFS + RES_SCALE (15));
+							r.extent.width = RES_SCALE (i + 1);
+							r.extent.height = RES_SCALE (1);
+							switch (i)
+							{
 							case 0:
 								r.corner.x = CAPTAIN_XOFFS + RES_SCALE (15);
 								i = CAPTAIN_WIDTH - RES_SCALE ((15 + 1) << 1);
@@ -681,38 +713,39 @@ PostProcessStatus (ELEMENT *ShipPtr)
 								// Should not happen.
 								c = UNDEFINED_COLOR;  // Keeping compiler quiet.
 								break;
+							}
+							DrawFilledRectangle (&r);
+							r.corner.x += i + r.extent.width;
+							DrawFilledRectangle (&r);
+							r.corner.x -= i;
+							r.extent.width = i;
 						}
-						DrawFilledRectangle (&r);
-						r.corner.x += i + r.extent.width;
-						DrawFilledRectangle (&r);
-						r.corner.x -= i;
-						r.extent.width = i;
-					}
-					else
-					{
-						if ((i -= 5) > 2)
-							c = BLACK_COLOR;
 						else
 						{
-							static const Color flash_tab2[] =
+							if ((i -= 5) > 2)
+								c = BLACK_COLOR;
+							else
 							{
-								BUILD_COLOR (MAKE_RGB15_INIT (0x17, 0x00, 0x00), 0x2B),
-								BUILD_COLOR (MAKE_RGB15_INIT (0x0F, 0x00, 0x00), 0x2D),
-								BUILD_COLOR (MAKE_RGB15_INIT (0x0B, 0x00, 0x00), 0x2E),
-							};
+								static const Color flash_tab2[] =
+								{
+									BUILD_COLOR (MAKE_RGB15_INIT (0x17, 0x00, 0x00), 0x2B),
+									BUILD_COLOR (MAKE_RGB15_INIT (0x0F, 0x00, 0x00), 0x2D),
+									BUILD_COLOR (MAKE_RGB15_INIT (0x0B, 0x00, 0x00), 0x2E),
+								};
 
-							c = flash_tab2[i];
-						}
-						r.corner.x = CAPTAIN_XOFFS
+								c = flash_tab2[i];
+							}
+							r.corner.x = CAPTAIN_XOFFS
 								+ (CAPTAIN_WIDTH >> 1) - IF_HD (2);
-						r.corner.y = y + CAPTAIN_YOFFS
-								 + ((CAPTAIN_HEIGHT + RES_SCALE (1)) >> 1) - IF_HD (2);
-						r.extent.width = RES_SCALE (1);
-						r.extent.height = RES_SCALE (1);
+							r .corner.y = y + CAPTAIN_YOFFS
+								+ ((CAPTAIN_HEIGHT + RES_SCALE (1)) >> 1) - IF_HD (2);
+							r.extent.width = RES_SCALE (1);
+							r.extent.height = RES_SCALE (1);
+						}
 					}
+					SetContextForeGroundColor (c);
+					DrawFilledRectangle (&r);
 				}
-				SetContextForeGroundColor (c);
-				DrawFilledRectangle (&r);
 			}
 		}
 
@@ -720,10 +753,7 @@ PostProcessStatus (ELEMENT *ShipPtr)
 		old_status_flags = (old_status_flags ^ cur_status_flags) &
 				(LEFT | RIGHT | THRUST | WEAPON | SPECIAL | LOW_ON_ENERGY);
 
-		CSPtr = &StarShipPtr->RaceDescPtr->ship_data.captain_control;
-		redraw_flags = CSPtr->redraw_flags;
-
-		if (old_status_flags || redraw_flags)
+		if (old_status_flags)
 		{
 			if (old_status_flags & LOW_ON_ENERGY)
 			{
@@ -732,16 +762,9 @@ PostProcessStatus (ELEMENT *ShipPtr)
 				else
 					DrawCrewFuelString (y, -1);
 			}
-
-			old_status_flags &= (LEFT | RIGHT | THRUST | WEAPON | SPECIAL);
-			if (redraw_flags && ShipPtr->crew_level != 0)
-			{
-				DrawCaptainWindowAnimation (CSPtr, y, redraw_flags);
-			}
 		}
 
 		StarShipPtr->old_status_flags = cur_status_flags;
-		CSPtr->redraw_flags = 0;
 	}
 }
 


### PR DESCRIPTION
Including:
1) Smooth and more optimized animations of captain portraits in melee
2) Special case for shofixti when detonating GD (only graphical changes). First frame in explosion sequence would be unique
3) Adapted bugzilla bug#444 for new system (androsyn special animation state in comet form)4
4) Fixed a bug when BATT indicator wasn't lit if there is not enough energy to transform into comet form
5) Fixed a bug when Androsyn loses its turn speed if it fails to transform back from comet form
6) Fixed Pkunk reincarnation being off with Extended option enabled (dead ships don't lose momentum)

Misc:
1) Fixed a bug when atrifacts are left on melee screen from explosions if:
    a) No obstacles cheat is ON
    b) Extended is ON so dead ships won't lose their momentum
    c) Both ships are dead (stalemate or shofixti GD kill)
2) Various white-space clean-ups
