### PR TITLE
Ship desc update & cost string color fix

### DIFF
--- a/src/uqm/build.h
+++ b/src/uqm/build.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-#define NAME_OFFSET 6
+#define NAME_OFFSET 5
 #define NUM_CAPTAINS_NAMES 16
 
 #define PickCaptainName() (((COUNT)TFB_Random () \

--- a/src/uqm/outfit.c
+++ b/src/uqm/outfit.c
@@ -101,7 +101,7 @@ DrawModuleStrings (MENU_STATE *pMS, BYTE NewModule)
 			SetContextFont (TinyFontBold);
 
 		if ((GLOBAL_SIS (ResUnits)) 
-				> (DWORD)((GLOBAL (ModuleCost[NewModule])
+				>= (DWORD)((GLOBAL (ModuleCost[NewModule])
 				* MODULE_COST_SCALE))) 
 			SetContextForeGroundColor (BRIGHT_GREEN_COLOR);
 		else

--- a/src/uqm/supermelee/buildpick.c
+++ b/src/uqm/supermelee/buildpick.c
@@ -169,7 +169,6 @@ GetToolTipFrameRect (RECT *r)
 
 #define RACE_NAME_OFFSET 0
 #define RACE_SHIP_OFFSET 3
-#define RACE_DESC_OFFSET 5
 
 void
 DrawTooltip (SHIP_INFO *SIPtr)
@@ -210,7 +209,8 @@ DrawTooltip (SHIP_INFO *SIPtr)
 	SetContextForeGroundColor (TOOLTIP_COLOR_DESC_FRONT);
 
 	utf8StringCopy (buf, sizeof buf,
-			GET_STRING (SIPtr->race_strings, RACE_DESC_OFFSET));
+			GET_STRING (SIPtr->race_strings, 
+				GetStringTableCount (SIPtr->race_strings) - 1));
 	ptr = strtok (buf, delim);
 
 	Text.baseline.y += RES_SCALE (2);


### PR DESCRIPTION
-Moved ship descriptions to the end of file to prevent errors in naming with old and core saves.

-Fixed a bug when module cost displayed red when the player has the exact amount of RU to afford it.