### PR TITLE
Expanded DrawOval and DrawFilledOval functions

### DIFF
--- a/src/libs/gfxlib.h
+++ b/src/libs/gfxlib.h
@@ -277,6 +277,14 @@ typedef struct rect
 	EXTENT extent;
 } RECT;
 
+// Kruzen: Thanks to JMS, using this to draw ovals
+// Overflows happen in HD with Starmap and max zoom (Fuel circles)
+typedef struct drect
+{
+	DPOINT corner;
+	DEXTENT extent;
+} DRECT;
+
 typedef struct line
 {
 	POINT first, second;
@@ -308,6 +316,17 @@ MAKE_DEXTENT (SDWORD width, SDWORD height)
 {
 	DEXTENT ext = {width, height};
 	return ext;
+}
+
+// Kruzen: Some DrawOval() calls still use standard rect where overflow is impossible as it's 2 figures away from that
+// Used to draw SOI and planet orbits
+// To avoid any typedef conflicts - transform standard RECT to DRECT
+static inline DRECT
+RECT_TO_DRECT (RECT r)
+{
+	DRECT dr = { {r.corner.x, r.corner.y}, {r.extent.width, r.extent.height} };
+
+	return dr;
 }
 
 //static inline void

--- a/src/libs/graphics/clipline.c
+++ b/src/libs/graphics/clipline.c
@@ -19,11 +19,11 @@
 #include "gfxintrn.h"
 
 INTERSECT_CODE
-_clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
+_clip_line (const DRECT *pClipRect, BRESENHAM_LINE *pLine)
 {
-	COORD p;
-	COORD x0, y0, xmin, ymin, xmax, ymax;
-	SIZE abs_delta_x, abs_delta_y;
+	SDWORD p;
+	SDWORD x0, y0, xmin, ymin, xmax, ymax;
+	SDWORD abs_delta_x, abs_delta_y;
 	INTERSECT_CODE intersect_code;
 
 	xmin = pClipRect->corner.x;
@@ -94,7 +94,7 @@ _clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
 	}
 	else
 	{
-		COORD x1, y1;
+		SDWORD x1, y1;
 
 		p = pLine->first.x;
 		x1 = pLine->second.x - p;
@@ -122,26 +122,26 @@ _clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
 
 		if (abs_delta_x > abs_delta_y)
 		{
-			SIZE half_dx;
+			SDWORD half_dx;
 
 			half_dx = abs_delta_x >> 1;
 			if (x0 < xmin)
 			{
-				if ((y0 = (COORD)(((long)abs_delta_y *
+				if ((y0 = (SDWORD)(((long)abs_delta_y *
 						(x0 = xmin) + half_dx) / abs_delta_x)) > ymax)
 					return ((INTERSECT_CODE)0);
 				intersect_code |= INTERSECT_LEFT;
 			}
 			if (x1 > xmax)
 			{
-				if ((y1 = (COORD)(((long)abs_delta_y *
+				if ((y1 = (SDWORD)(((long)abs_delta_y *
 						(x1 = xmax) + half_dx) / abs_delta_x)) < ymin)
 					return ((INTERSECT_CODE)0);
 				intersect_code |= INTERSECT_RIGHT;
 			}
 			if (y0 < ymin)
 			{
-				if ((x0 = (COORD)(((long)abs_delta_x *
+				if ((x0 = (SDWORD)(((long)abs_delta_x *
 						(y0 = ymin) - half_dx + (abs_delta_y - 1)) /
 						abs_delta_y)) > xmax)
 					return ((INTERSECT_CODE)0);
@@ -150,7 +150,7 @@ _clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
 			}
 			if (y1 > ymax)
 			{
-				if ((x1 = (COORD)(((long)abs_delta_x *
+				if ((x1 = (SDWORD)(((long)abs_delta_x *
 						((y1 = ymax) + 1) - half_dx + (abs_delta_y - 1)) /
 						abs_delta_y) - 1) < xmin)
 					return ((INTERSECT_CODE)0);
@@ -160,26 +160,26 @@ _clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
 		}
 		else
 		{
-			SIZE half_dy;
+			SDWORD half_dy;
 
 			half_dy = abs_delta_y >> 1;
 			if (y0 < ymin)
 			{
-				if ((x0 = (COORD)(((long)abs_delta_x *
+				if ((x0 = (SDWORD)(((long)abs_delta_x *
 						(y0 = ymin) + half_dy) / abs_delta_y)) > xmax)
 					return ((INTERSECT_CODE)0);
 				intersect_code |= INTERSECT_TOP;
 			}
 			if (y1 > ymax)
 			{
-				if ((x1 = (COORD)(((long)abs_delta_x *
+				if ((x1 = (SDWORD)(((long)abs_delta_x *
 						(y1 = ymax) + half_dy) / abs_delta_y)) < xmin)
 					return ((INTERSECT_CODE)0);
 				intersect_code |= INTERSECT_BOTTOM;
 			}
 			if (x0 < xmin)
 			{
-				if ((y0 = (COORD)(((long)abs_delta_y *
+				if ((y0 = (SDWORD)(((long)abs_delta_y *
 						(x0 = xmin) - half_dy + (abs_delta_x - 1)) /
 						abs_delta_x)) > ymax)
 					return ((INTERSECT_CODE)0);
@@ -188,7 +188,7 @@ _clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
 			}
 			if (x1 > xmax)
 			{
-				if ((y1 = (COORD)(((long)abs_delta_y *
+				if ((y1 = (SDWORD)(((long)abs_delta_y *
 						((x1 = xmax) + 1) - half_dy + (abs_delta_x - 1)) /
 						abs_delta_x) - 1) < ymin)
 					return ((INTERSECT_CODE)0);
@@ -221,18 +221,18 @@ _clip_line (const RECT *pClipRect, BRESENHAM_LINE *pLine)
 	if (!(intersect_code & INTERSECT_ALL_SIDES))
 	{
 		if (abs_delta_x > abs_delta_y)
-			pLine->error_term = -(SIZE)(abs_delta_x >> 1);
+			pLine->error_term = -(SDWORD)(abs_delta_x >> 1);
 		else
-			pLine->error_term = -(SIZE)(abs_delta_y >> 1);
+			pLine->error_term = -(SDWORD)(abs_delta_y >> 1);
 	}
 	else
 	{
 		intersect_code &= ~INTERSECT_NOCLIP;
 		if (abs_delta_x > abs_delta_y)
-			pLine->error_term = (SIZE)((x0 * (long)abs_delta_y) -
+			pLine->error_term = (SDWORD)((x0 * (long)abs_delta_y) -
 					(y0 * (long)abs_delta_x)) - (abs_delta_x >> 1);
 		else
-			pLine->error_term = (SIZE)((y0 * (long)abs_delta_x) -
+			pLine->error_term = (SDWORD)((y0 * (long)abs_delta_x) -
 					(x0 * (long)abs_delta_y)) - (abs_delta_y >> 1);
 	}
 

--- a/src/libs/graphics/drawable.h
+++ b/src/libs/graphics/drawable.h
@@ -26,9 +26,9 @@
 
 typedef struct bresenham_line
 {
-	POINT first, second;
-	SIZE abs_delta_x, abs_delta_y;
-	SIZE error_term;
+	DPOINT first, second;
+	SDWORD abs_delta_x, abs_delta_y;
+	SDWORD error_term;
 	BOOLEAN end_points_exchanged;
 	INTERSECT_CODE intersect_code;
 } BRESENHAM_LINE;
@@ -73,7 +73,7 @@ typedef struct
 	FRAME FramePtr;
 } IMAGE_BOX;
 
-extern INTERSECT_CODE _clip_line (const RECT *pClipRect,
+extern INTERSECT_CODE _clip_line (const DRECT *pClipRect,
 		BRESENHAM_LINE *pLine);
 
 extern void *_GetCelData (uio_Stream *fp, DWORD length);

--- a/src/uqm/planets/planets.h
+++ b/src/uqm/planets/planets.h
@@ -359,8 +359,8 @@ extern void ExploreSolarSys (void);
 extern void DrawStarBackGround (void);
 extern FRAME GetStarBackFround (void);
 extern void XFormIPLoc (POINT *pIn, POINT *pOut, BOOLEAN ToDisplay);
-extern void DrawOval (RECT *pRect, BYTE num_off_pixels, BOOLEAN scaled);
-extern void DrawFilledOval (RECT *pRect);
+extern void DrawOval (DRECT *pRect, BYTE num_off_pixels, BOOLEAN scaled);
+extern void DrawFilledOval (DRECT *pRect);
 extern void DrawEllipse (int cx, int cy, int rx, int ry, int shear,
 		int filled, int dotted);
 extern void DrawRotatedEllipse (int cx, int cy, int rx, int ry,

--- a/src/uqm/planets/solarsys.c
+++ b/src/uqm/planets/solarsys.c
@@ -1308,14 +1308,16 @@ static void
 DrawOrbit (PLANET_DESC *planet, int sizeNumer, int dyNumer, int denom)
 {
 	RECT r;
+	DRECT dr;
 
 	GetPlanetOrbitRect (&r, planet, sizeNumer, dyNumer, denom);
 
+	dr = RECT_TO_DRECT (r);
 	SetContextForeGroundColor (planet->temp_color);
 	if (!optUnscaledStarSystem)
-		DrawOval (&r, RES_BOOL (1, 6), FALSE);
+		DrawOval (&dr, RES_BOOL (1, 6), FALSE);
 	else
-		DrawOval (&r, 1, FALSE);
+		DrawOval (&dr, 1, FALSE);
 }
 
 static SIZE


### PR DESCRIPTION
Expanded DrawOval and DrawFilledOval functions to support 4-byte RECTs called DRECTs.

Should avoid most of the overflows related to circles. Fixes are still not finished.