### PR TITLE
Fixed race name text sometimes have incorrect offset

### DIFF
--- a/src/uqm/planets/pstarmap.c
+++ b/src/uqm/planets/pstarmap.c
@@ -907,7 +907,8 @@ CheckTextsIntersect (RECT *curr, RECT *prev)
 			((prev->corner.y + prev->extent.height) <= curr->corner.y))
 		return 0;
 
-	return ((prev->extent.height + RES_SCALE (1)) - (curr->corner.y - prev->corner.y));
+	return ((prev->extent.height + RES_SCALE (1)) - abs (curr->corner.y -
+			prev->corner.y));
 }
 
 static void


### PR DESCRIPTION
Fixed race name text sometimes have incorrect offset, making it appear way further than it should be