### PR TITLE
Graphics glitch fix in shipyard menu

### DIFF
--- a/src/uqm/shipyard.c
+++ b/src/uqm/shipyard.c
@@ -611,7 +611,7 @@ DrawRaceStrings (MENU_STATE *pMS, BYTE NewRaceItem)
 	r.extent.height = RES_SCALE (12);
 	BatchGraphics ();
 	ClearSISRect (CLEAR_SIS_RADAR);
-	SetContextForeGroundColor (BRIGHT_GREEN_COLOR);
+	SetContextForeGroundColor (DKGRAY_COLOR);
 
 	if (!IS_DOS)
 	{


### PR DESCRIPTION
Fixed graphical glitch when a bright green stripe can appear when trying to add esqort ship in shipyard menu