### PR TITLE
Fixes for commit 51208d5

### DIFF
--- a/src/uqm/planets/lander.c
+++ b/src/uqm/planets/lander.c
@@ -2337,6 +2337,8 @@ FreeLanderData (void)
 		DestroyDrawable (ReleaseDrawable (LanderFrame[i]));
 		LanderFrame[i] = 0;
 	}
+
+	LanderUpgradesFlag = 0;
 }
 
 void


### PR DESCRIPTION
Fixed lander not being properly masked if the game was switched from SD to HD and vice versa without game restart.
Fix for 51208d5