### PR TITLE
Update clipboard.c

### DIFF
--- a/src/libs/graphics/sdl/clipboard.c
+++ b/src/libs/graphics/sdl/clipboard.c
@@ -102,6 +102,6 @@ CopySurfaceToClipboard (SDL_Surface *surface)
 #else
 	log_add (log_Warning, "Clipboard functionality is not implemented on "
 			"this platform.");
-	return FALSE;
+	return SDL_FALSE;
 #endif
 }


### PR DESCRIPTION
FALSE is not defined under gnu99, causing compile errors under Arch Linux.