### PR TITLE
Slylandro Probe encounter rate fix, Gas giant generation fix

### DIFF
--- a/src/uqm/hyper.c
+++ b/src/uqm/hyper.c
@@ -346,10 +346,9 @@ check_hyperspace_encounter (void)
 				if (Type == SLYLANDRO_SHIP)
 				{
 					encounter_flags = ONE_SHOT_ENCOUNTER;
-
-					percent = 100;
-
-					if (GET_GAME_STATE (STARBASE_AVAILABLE))
+					if (!GET_GAME_STATE (STARBASE_AVAILABLE))
+						percent = 100;
+					else
 						percent *= GET_GAME_STATE (SLYLANDRO_MULTIPLIER);
 
 					if (optNoHQEncounters)

--- a/src/uqm/planets/generate/gendefault.c
+++ b/src/uqm/planets/generate/gendefault.c
@@ -353,12 +353,18 @@ GenerateWorlds (BYTE whichType)
 		planet = FIRST_LARGE_ROCKY_WORLD +
 				RandomContext_Random (SysGenRNG) %
 				(NUMBER_OF_LARGE_ROCKY_WORLDS - 2);
+		// Skip over rainbow_world and shattered_world, which are adjacent.
+		if (planet >= RAINBOW_WORLD)
+			planet += 2;
 	}
 	else if (whichType & ALL_ROCKY)
 	{
 		planet = FIRST_ROCKY_WORLD +
 				RandomContext_Random (SysGenRNG) %
 				(NUMBER_OF_ROCKY_WORLDS - 2);
+		// Skip over rainbow_world and shattered_world, which are adjacent.
+		if (planet >= RAINBOW_WORLD)
+			planet += 2;
 	}
 	else if (whichType & ONLY_LARGE)
 	{
@@ -366,6 +372,9 @@ GenerateWorlds (BYTE whichType)
 				RandomContext_Random (SysGenRNG) %
 				(NUMBER_OF_LARGE_ROCKY_WORLDS
 					+ NUMBER_OF_GAS_GIANTS - 2);
+		// Skip over rainbow_world and shattered_world, which are adjacent.
+		if (planet >= RAINBOW_WORLD)
+			planet += 2;
 	}
 	else if (whichType & ONLY_GAS)
 	{
@@ -373,9 +382,6 @@ GenerateWorlds (BYTE whichType)
 				RandomContext_Random (SysGenRNG) %
 				NUMBER_OF_GAS_GIANTS;
 	}
-	// Skip over rainbow_world and shattered_world, which are adjacent.
-	if (planet >= RAINBOW_WORLD)
-		planet += 2;
 
 	return planet;
 }
@@ -387,6 +393,7 @@ GenerateGasGiantRanged (SOLARSYS_STATE *solarSys)
 	PLANET_DESC *pPlanet;
 	BYTE i;
 #define DWARF_GASG_DIST SCALE_RADIUS (12)
+	DWORD rand = RandomContext_GetSeed (SysGenRNG);
 
 	for (i = 0; i < pSunDesc->NumPlanets; i++)
 	{
@@ -394,6 +401,10 @@ GenerateGasGiantRanged (SOLARSYS_STATE *solarSys)
 			break;
 	}
 
+	if (i == pSunDesc->NumPlanets)
+		i = rand % (pSunDesc->NumPlanets);
+	else
+		i += rand % (pSunDesc->NumPlanets - i);
 	pSunDesc->PlanetByte = i;
 	pPlanet = &solarSys->PlanetDesc[pSunDesc->PlanetByte];
 
@@ -402,7 +413,6 @@ GenerateGasGiantRanged (SOLARSYS_STATE *solarSys)
 	if (solarSys->PlanetDesc[i].radius < DWARF_GASG_DIST)
 	{
 		COUNT angle;
-		DWORD rand = RandomContext_GetSeed (SysGenRNG);
 
 		pPlanet->radius =
 				RangeMinMax (DWARF_GASG_DIST, MAX_PLANET_RADIUS, rand);


### PR DESCRIPTION
This sets the Slylandro Probe back to the normal (core) behavior before Nomad mode was added.
Also, fixing issues with gas giant generation causing crash.