### PR TITLE
Fix Hard Mode, when Thraddash are Allies during UQ/KA mission, cannot collect Aqua Helix

### DIFF
--- a/MegaMod Changelog.txt
+++ b/MegaMod Changelog.txt
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Fixed F10 exit being overdrawn in some cases
 - Fixed flash context "repairing" frame during exit
 - Fixed F10 exit issue when shipyard powerlines being drawn over exit dialog box
+- Fixed Hard Mode Thraddash Allies during UQ/KA mission not able to acquire Aqua Helix
 
 ## [v0.8.3] - 2024-04-11
 

--- a/src/uqm/planets/generate/genthrad.c
+++ b/src/uqm/planets/generate/genthrad.c
@@ -152,6 +152,7 @@ GenerateThraddash_generateOrbital (SOLARSYS_STATE *solarSys,
 		}
 		else if (DIF_HARD
 					&& CurStarDescPtr->Index == AQUA_HELIX_DEFINED
+					&& !GET_GAME_STATE (HELIX_UNPROTECTED)
 					&& !(GET_GAME_STATE (HM_ENCOUNTERS)
 						& 1 << THRADDASH_ENCOUNTER)
 					&& (StartSphereTracking (THRADDASH_SHIP)
@@ -188,7 +189,7 @@ GenerateThraddash_generateOrbital (SOLARSYS_STATE *solarSys,
 				ReinitQueue (&GLOBAL(npc_built_ship_q));
 				GetGroupInfo (GROUPS_RANDOM, GROUP_LOAD_IP);
 
-				if (Survivors)
+				if (Survivors && !GET_GAME_STATE (HELIX_UNPROTECTED))
 					return true;
 
 				{


### PR DESCRIPTION
* When allied to Thraddash during the UQ/KA mission, the dialog drops you to IP, and if you come back it goes back to dialog.
* After fix, you drop into orbit, and if you revisit, no dialog.