### PR TITLE
fix compile errors

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -88,7 +88,7 @@ BOOLEAN optLoadGame;
 OPT_ENABLABLE optCustomBorder;
 int optSeedType;
 int optCustomSeed;
-BOOLEAN optShipSeed;
+OPT_ENABLABLE optShipSeed;
 int optSphereColors;
 int spaceMusicBySOI;
 int optSpaceMusic;

--- a/src/options.h
+++ b/src/options.h
@@ -77,7 +77,7 @@ extern BOOLEAN optLoadGame;
 extern OPT_ENABLABLE optCustomBorder;
 extern int optSeedType;
 extern int optCustomSeed;
-extern BOOLEAN optShipSeed;
+extern OPT_ENABLABLE optShipSeed;
 extern int optSphereColors;
 extern int spaceMusicBySOI;
 extern int optSpaceMusic;

--- a/src/uqm/load.c
+++ b/src/uqm/load.c
@@ -33,7 +33,7 @@
 #include "libs/tasklib.h"
 #include "libs/log.h"
 #include "libs/misc.h"
-
+#include "master.h"
 //#define DEBUG_LOAD
 
 ACTIVITY NextActivity;

--- a/src/uqm/restart.c
+++ b/src/uqm/restart.c
@@ -45,6 +45,7 @@
 #include "options.h"
 #include "cons_res.h"
 #include "build.h"
+#include "master.h"
 
 #include "libs/resource/stringbank.h"
 // for StringBank_Create() & SplitString()


### PR DESCRIPTION
fixes type mismatch on optShipSeed, allowing the code to compile under Arch Linux.  Also add missing includes