### PR TITLE
Reverse accidental removal by StarSeed of Kruzen's nameplate bugfix

### DIFF
--- a/src/uqm/planets/pstarmap.c
+++ b/src/uqm/planets/pstarmap.c
@@ -906,7 +906,8 @@ CheckTextsIntersect (RECT *curr, RECT *prev)
 			((prev->corner.y + prev->extent.height) <= curr->corner.y))
 		return 0;
 
-	return ((prev->extent.height + RES_SCALE (1)) - (curr->corner.y - prev->corner.y));
+	return ((prev->extent.height + RES_SCALE (1)) - abs (curr->corner.y -
+			prev->corner.y));
 }
 
 static void


### PR DESCRIPTION
Starseed accidentally reverted Kruzen's nameplate bugfix.  I just noticed it today.