### PR TITLE
Setup menu seed fixes, and head start UQ probe bypass

### DIFF
--- a/src/uqm/planets/generate/gensol.c
+++ b/src/uqm/planets/generate/gensol.c
@@ -75,8 +75,11 @@ const GenerateFunctions generateSolFunctions = {
 static bool
 GenerateSol_initNpcs (SOLARSYS_STATE *solarSys)
 {
+	if (optHeadStart)
+		SET_GAME_STATE (PROBE_MESSAGE_DELIVERED, 1);
 	GLOBAL (BattleGroupRef) = GET_GAME_STATE (URQUAN_PROBE_GRPOFFS);
-	if (GLOBAL (BattleGroupRef) == 0)
+	if (GLOBAL (BattleGroupRef) == 0 &&
+			!GET_GAME_STATE (PROBE_MESSAGE_DELIVERED))
 	{
 		CloneShipFragment (URQUAN_DRONE_SHIP,
 				&GLOBAL (npc_built_ship_q), 0);


### PR DESCRIPTION
Force seed to PrimeA when Seed Type is Prime. Immediately set optCustomSeed so it doesn't flip flop in setup menu. Also fix the UQ Probe in optHeadStart so it goes away and stays away.