### PR TITLE
Yehat Rebels gift ship small bugfix

### DIFF
--- a/src/uqm/comm/rebel/rebel.c
+++ b/src/uqm/comm/rebel/rebel.c
@@ -282,7 +282,7 @@ RebelInfo (RESPONSE_REF R)
 static void
 Rebels (RESPONSE_REF R)
 {
-	SBYTE NumVisits;
+	COUNT NumVisits;
 
 	if (PLAYER_SAID (R, how_goes_revolution))
 	{


### PR DESCRIPTION
EscortFeasabilityStudy can return large enough numbers that the variable needs to be a COUNT not SBYTE (goes negative).