### PR TITLE
Fix macOS build on arm64

### DIFF
--- a/build/unix/config_proginfo_build
+++ b/build/unix/config_proginfo_build
@@ -90,7 +90,7 @@ case "$HOST_SYSTEM" in
 				EXTRA_PLATFORM_GCC_FLAGS_LINK='-mmacosx-version-min=10.7 -arch x86_64'
 				;;
 			*)
-				echo "Unknown architecture: $ARCH"
+				echo "Unknown architecture: $(uname -m)" >&2
 				exit 1
 				;;
 		esac

--- a/build/unix/config_proginfo_build
+++ b/build/unix/config_proginfo_build
@@ -77,9 +77,23 @@ useGccBuildTools() {
 }
 case "$HOST_SYSTEM" in
 	Darwin)
-		EXTRA_PLATFORM_GCC_FLAGS_COMPILE_C='-mmacosx-version-min=10.6 -arch x86_64'
-		EXTRA_PLATFORM_GCC_FLAGS_COMPILE_OBJC='-mmacosx-version-min=10.6 -arch x86_64'
-		EXTRA_PLATFORM_GCC_FLAGS_LINK='-mmacosx-version-min=10.6 -arch x86_64'
+		case $(uname -m) in
+			arm64)
+				EXTRA_PLATFORM_GCC_FLAGS_MKDEP_C='-I/opt/homebrew/include -arch arm64'
+				EXTRA_PLATFORM_GCC_FLAGS_COMPILE_C='-mmacosx-version-min=10.7 -I/opt/homebrew/include -arch arm64'
+				EXTRA_PLATFORM_GCC_FLAGS_COMPILE_OBJC='-mmacosx-version-min=10.7 -arch arm64'
+				EXTRA_PLATFORM_GCC_FLAGS_LINK='-mmacosx-version-min=10.7 -L/opt/homebrew/lib -arch arm64'
+				;;
+			x86_64)
+				EXTRA_PLATFORM_GCC_FLAGS_COMPILE_C='-mmacosx-version-min=10.7 -arch x86_64'
+				EXTRA_PLATFORM_GCC_FLAGS_COMPILE_OBJC='-mmacosx-version-min=10.7 -arch x86_64'
+				EXTRA_PLATFORM_GCC_FLAGS_LINK='-mmacosx-version-min=10.7 -arch x86_64'
+				;;
+			*)
+				echo "Unknown architecture: $ARCH"
+				exit 1
+				;;
+		esac
 		useGccBuildTools
 		;;
 	WINSCW)


### PR DESCRIPTION
Fixes local builds on Arm based Macs.

- on Macs, build script now checks which architecture the system is on and adjusts build flags appropriately:
  - On arm add `/opt/homebrew/(include/lib)` as homebrew installs to `/opt/homebrew` on arm macs
  - Add the appropriate `-arch flag`
- Modern versions of SDL2 (which is what homebrew installs) have a minimum macOS version of 10.7 so I also bumped that

I've tested building on an M1 Mac running macOS 26.2 (Tahoe) and an Intel Mac running macOS 15.6 (Sequoia), both produced working builds